### PR TITLE
Specify PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
 		}
 	],
 	"require": {
+		"php": ">=5.4.0",
 		"laravel/framework": "4.2.*",
 		"laracasts/flash": "~1.0",
 		"guzzlehttp/guzzle": "~4.2",


### PR DESCRIPTION
Partial fix for #58, assuming 5.4 is correct