### PR TITLE
Snapshots command

### DIFF
--- a/app/Console/Commands/CreateSnapshots.php
+++ b/app/Console/Commands/CreateSnapshots.php
@@ -5,18 +5,7 @@ use Sprint;
 
 class CreateSnapshots extends Command {
 
-	/**
-	 * The console command name.
-	 *
-	 * @var string
-	 */
 	protected $name = 'snapshots:create';
-
-	/**
-	 * The console command description.
-	 *
-	 * @var string
-	 */
 	protected $description = 'This command creates snapshots of all sprints in Phragile.';
 
 	/**

--- a/app/Console/Commands/CreateSnapshots.php
+++ b/app/Console/Commands/CreateSnapshots.php
@@ -1,0 +1,34 @@
+<?php namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Sprint;
+
+class CreateSnapshots extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'snapshots:create';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'This command creates snapshots of all sprints in Phragile.';
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function fire()
+	{
+		foreach (Sprint::all() as $sprint)
+		{
+			$sprint->createSnapshot();
+		}
+	}
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,6 +12,7 @@ class Kernel extends ConsoleKernel {
 	 */
 	protected $commands = [
 		'App\Console\Commands\Inspire',
+		'App\Console\Commands\CreateSnapshots',
 	];
 
 	/**

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -4,6 +4,7 @@ use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\MinkExtension\Context\MinkContext;
+use PHPUnit_Framework_Assert as PHPUnit;
 
 /**
  * Defines application features from the specific context.
@@ -388,5 +389,33 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	public function iPasteTheCopiedPhabricatorId()
 	{
 		$this->fillField('title', $this->phabricatorProjectID);
+	}
+
+	/**
+	 * @Given I know the number of snapshots
+	 */
+	public function iKnowTheNumberOfSnapshots()
+	{
+		$this->numberOfSnapshots = SprintSnapshot::count();
+	}
+
+	/**
+	 * @When I execute artisan :command
+	 */
+	public function iExecuteArtisan($command)
+	{
+		Artisan::call($command);
+	}
+
+	/**
+	 * @Then I should have created one snapshot for each sprint
+	 */
+	public function iShouldHaveCreatedOneSnapshotForEachSprint()
+	{
+		$numberOfSprints = Sprint::count();
+
+		PHPUnit::assertSame($this->numberOfSnapshots + $numberOfSprints, SprintSnapshot::count());
+
+		SprintSnapshot::take($numberOfSprints)->delete(); // cleaning up
 	}
 }

--- a/tests/acceptance/sprint_snapshots.feature
+++ b/tests/acceptance/sprint_snapshots.feature
@@ -33,3 +33,8 @@ Feature: Sprint Snapshots
     When I go to the latest snapshot page of "Sprint 42"
     And I click "Delete snapshot"
     Then "Sprint 42" should not have any snapshots
+
+  Scenario: Automated snapshots
+    Given I know the number of snapshots
+    When I execute artisan "snapshots:create"
+    Then I should have created one snapshot for each sprint


### PR DESCRIPTION
ping @WMDE-Fisch or @KaiNissen 

This creates an [artisan command](http://laravel.com/docs/5.0/commands) which allows us to create snapshots for all Phragile sprints at once (e.g. daily via cron jobs) by executing `php artisan snapshots:create`.