### PR TITLE
Add missing parameters and settings to Elixir functions

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,7 +1,9 @@
 var elixir = require('laravel-elixir');
 
+elixir.config.sourcemaps = false;
+
 elixir(function(mix) {
-    mix.less('style.less');
+    mix.less('style.less', 'public/css/style.css');
 
     mix.scripts([
         '../assets/bower_components/d3/d3.js',
@@ -15,18 +17,18 @@ elixir(function(mix) {
         'pie_charts.js',
         '../assets/bower_components/list.js/dist/list.js',
         'sprint_backlog.js'
-    ], 'public/js/sprint_overview.js');
+    ], 'public/js/sprint_overview.js', 'resources/js');
 
     mix.scripts([
         '../assets/bower_components/jquery/dist/jquery.js',
         '../assets/bower_components/bootstrap/dist/js/bootstrap.js'
-    ], 'public/js/main.js');
+    ], 'public/js/main.js', 'resources/js');
 
     mix.scripts(
         '../assets/bower_components/bootstrap-datepicker/js/bootstrap-datepicker.js',
-        'public/js/datepicker.js'
+        'public/js/datepicker.js', 'resources/js'
     ).styles(
         '../assets/bower_components/bootstrap-datepicker/css/datepicker3.css',
-        'public/css/datepicker.css'
+        'public/css/datepicker.css', 'resources/js'
     );
 });

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,7 +1,5 @@
 var elixir = require('laravel-elixir');
 
-elixir.config.sourcemaps = false;
-
 elixir(function(mix) {
     mix.less('style.less', 'public/css/style.css');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "gulp": "^3.9",
+    "gulp": "^3.8.8",
     "laravel-elixir": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "gulp": "^3.8.8",
-    "laravel-elixir": "*"
+    "laravel-elixir": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "gulp": "^3.8.8",
+    "gulp": "^3.9",
     "laravel-elixir": "*"
   }
 }


### PR DESCRIPTION
New version of compiled Javascript and CSS files has not been included in `burnup_frontend` branch. This is actually fine (in my opinion) but in that case I had to be regenerate those compiled files on my own.

When I run gulp I get css stylesheet compiled but to the wrong file (`public/css/app.css` instead of `public/css/style.css`). Gulp has also generated `app.css.map` which, as I understand, is not used by Phragile. Javascript files fail to compile as Gulp could not found input Javascript files.

This problem may be resolved by adding some paths to the `Gulpfile`. CSS map file is also no longer generated (it could be also added to .gitignore file but it seems to me more reasonable not to create it at all).