### PR TITLE
Fix setting up the maximum value of the Y-axis

### DIFF
--- a/resources/js/chart_data.js
+++ b/resources/js/chart_data.js
@@ -125,7 +125,7 @@ var PHRAGILE = PHRAGILE || {};
              * @returns {int} - Maximal total number of points in the sprint
              */
             getMaxPoints: function () {
-                return d3.max(sprintData, function (day) { return day.scope; });
+                return d3.max(sprintData, function (day) { return parseInt(day.scope); });
             },
 
             /**


### PR DESCRIPTION
Y-axis should by adjusted accordingly to the maximum number of scope points throughout the whole sprint.
See below case when number of story points in the sprint has changed from 9 to 13 at some point (scope line does not fit the chart):
![phragile-scopeline-bug](https://cloud.githubusercontent.com/assets/12729452/8599290/daccbf68-265f-11e5-8c2c-bea66844d943.png)

Apparently this has been implemented but what was compared while looking for the maximum were string not numbers.