### PR TITLE
Fix problem with snapshot charts in Firefox

### DIFF
--- a/resources/js/progress_graph.js
+++ b/resources/js/progress_graph.js
@@ -12,7 +12,7 @@ var PHRAGILE = PHRAGILE || {};
     PHRAGILE.ProgressGraph = function (data, cssID, label) {
         data = data.filter(function (d) {
             var $snapshotDate = $('#snapshot-date'),
-                filterDate = $snapshotDate.length > 0 ? Date.parse($snapshotDate.text()) : new Date();
+                filterDate = $snapshotDate.length > 0 ? Date.parse($snapshotDate.text().replace(' ', 'T')) : new Date();
 
             return d.day <= filterDate;
         });


### PR DESCRIPTION
While switching from live version of the sprint to the snapshot burndown and burnup charts are not shown (see below):
![phragile-no-graphs-bug](https://cloud.githubusercontent.com/assets/12729452/8599502/2a7b95e2-2661-11e5-898f-86acbbb6a746.png)
The problem seems to appear in Firefox (version 38), while everything is OK in Chromium (ver 43).
It seems that implementation of `Date.parse` is more strict in Firefox and it requires for date to be in ISO 8061-defined format, i.e. `2015-07-09 14:26:11` is bad and `2015-07-09T14:26:11` is fine.
The solution proposed here is certainly not the only possible workaround, e.g. according to this: https://stackoverflow.com/questions/21984406/error-converting-datestring-to-date-object-in-firefox/21984717#21984717 changing hyphens to backslashes would also do the work.
I haven't tested this code on any other browsers.