### PR TITLE
Fix project column bug.

### DIFF
--- a/app/Phragile/Factory/SprintDataFactory.php
+++ b/app/Phragile/Factory/SprintDataFactory.php
@@ -133,6 +133,6 @@ class SprintDataFactory {
 
 	private function fetchProjectColumns()
 	{
-		return new ProjectColumnRepository($this->transactions, $this->phabricatorAPI);
+		return new ProjectColumnRepository($this->sprint->phid, $this->transactions, $this->phabricatorAPI);
 	}
 }

--- a/app/Phragile/ProjectColumnRepository.php
+++ b/app/Phragile/ProjectColumnRepository.php
@@ -7,9 +7,11 @@ class ProjectColumnRepository {
 	 */
 	private $projectColumns;
 	private $phabricator;
+	private $projectPHID;
 
-	public function __construct(array $transactions, PhabricatorAPI $phabricator)
+	public function __construct($projectPHID, array $transactions, PhabricatorAPI $phabricator)
 	{
+		$this->projectPHID = $projectPHID;
 		$this->phabricator = $phabricator;
 		$this->projectColumns = $this->fetchColumnData($transactions);
 	}
@@ -43,7 +45,7 @@ class ProjectColumnRepository {
 	{
 		return array_reduce($transactions, function($columns, $transaction)
 		{
-			if ($transaction['transactionType'] === 'projectcolumn')
+			if ($transaction['transactionType'] === 'projectcolumn' && $transaction['oldValue']['projectPHID'] === $this->projectPHID)
 			{
 				$columns[] = $transaction['newValue']['columnPHIDs'][0];
 				$columns[] = reset($transaction['oldValue']['columnPHIDs']);

--- a/tests/unit/TaskListTest.php
+++ b/tests/unit/TaskListTest.php
@@ -150,7 +150,7 @@ class TaskListTest extends TestCase {
 		return new TaskList($tasks, new StatusByWorkboardDispatcher(
 			$this->testProjectPHID,
 			new TransactionList($transactions),
-			new ProjectColumnRepository($transactions, $phabricatorAPI),
+			new ProjectColumnRepository($this->testProjectPHID, $transactions, $phabricatorAPI),
 			array_values($this->workboardColumns)
 		));
 	}


### PR DESCRIPTION
The bug appeared whenever the last column move of a task happened on a worboard other than the sprint's own workboard and the column's name was the same as one of sprint workboard columns (e.g. Done).
Phragile would then use the PHID of the other workboard's column too look up at what date a task was moved on the sprint workboard and not find anything. The tasks' statuses were still correct since the names were the same but the `closedTime` lookup failed.