### PR TITLE
Set MYSQL_ATTR_MAX_BUFFER_SIZE to 50M.

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -76,6 +76,9 @@ return [
 			'collation' => 'utf8_unicode_ci',
 			'prefix'    => '',
 			'strict'    => false,
+			'options' => defined('PDO::MYSQL_ATTR_MAX_BUFFER_SIZE') ? [
+				PDO::MYSQL_ATTR_MAX_BUFFER_SIZE => 50 * 1024 * 1024,
+			] : [],
 		],
 
 		'pgsql' => [


### PR DESCRIPTION
Sprint snapshots can become quite big (>1mb for medium sized sprints). It turned out that at a certain size the JSON blob got cut off which caused the deserialization to fail. My first idea was that the database couldn't handle large text but that was not the case. Instead it was a PDO limitation called `PDO::MYSQL_ATTR_MAX_BUFFER_SIZE` which can be increased in the database settings. Yay.