### PR TITLE
Fix https handling.

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends HttpKernel {
 		'Illuminate\Session\Middleware\StartSession',
 		'Illuminate\View\Middleware\ShareErrorsFromSession',
 		'App\Http\Middleware\VerifyCsrfToken',
+		'App\Http\Middleware\AllowAnyProxy',
 	];
 
 	/**

--- a/app/Http/Middleware/AllowAnyProxy.php
+++ b/app/Http/Middleware/AllowAnyProxy.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Http\Middleware;
+
+use Closure;
+
+class AllowAnyProxy {
+	/**
+	 * Adds the client IP to trusted proxies, thereby allowing SSL through server side proxies
+	 *
+	 * @param  \Illuminate\Http\Request  $request
+	 * @param  \Closure  $next
+	 * @return mixed
+	 */
+	public function handle($request, Closure $next)
+	{
+		$request->setTrustedProxies([$request->getClientIp()]);
+		return $next($request);
+	}
+}


### PR DESCRIPTION
This solves https://phabricator.wikimedia.org/T104452

CSS and JS assets were not loaded properly because Phragile did not correctly detect HTTPS connections on Heroku and Labs since both services use load balancers and web proxies altering the client request. This patch solves the problem by adding the client IP to the trusted proxies list and thereby allowing any proxies.