### PR TITLE
Consider merged tasks as done

### DIFF
--- a/app/Phragile/ClosedTimeByStatusFieldDispatcher.php
+++ b/app/Phragile/ClosedTimeByStatusFieldDispatcher.php
@@ -7,8 +7,11 @@ class ClosedTimeByStatusFieldDispatcher implements ClosedTimeDispatcher {
 
 	public function isClosingTransaction(array $transaction)
 	{
-		return $transaction['transactionType'] === 'status'
-			&& in_array($transaction['oldValue'], self::$STATUS_OPEN)
-			&& !in_array($transaction['newValue'], self::$STATUS_OPEN);
+		if ($transaction['transactionType'] === 'status') {
+			return in_array($transaction['oldValue'], self::$STATUS_OPEN) &&
+			       !in_array($transaction['newValue'], self::$STATUS_OPEN);
+		}
+
+		return $transaction['transactionType'] === 'mergedinto';
 	}
 }

--- a/tests/unit/BurndownChartTest.php
+++ b/tests/unit/BurndownChartTest.php
@@ -229,4 +229,19 @@ class BurndownChartTest extends TestCase {
 
 		$this->assertNull($burndown->getPointsClosedBeforeSprint());
 	}
+
+	public function testClosedPerDayDetectsMergedTasks()
+	{
+		$burndown = $this->mockWithTransactions(
+			$this->tasks,
+			[
+				'1' => [[
+					        'transactionType' => 'mergedinto',
+					        'dateCreated' => '1418040000', // Dec 8
+				        ]],
+			]
+		);
+
+		$this->assertSame(8, $burndown->getPointsClosedPerDay()['2014-12-08']);
+	}
 }


### PR DESCRIPTION
Merging a task as a duplicate isn't a status change but a custom
'mergedinto' transaction which has to be handled as well.

Fixes https://phabricator.wikimedia.org/T107863