### PR TITLE
Add ability to delete a sprint

### DIFF
--- a/app/Http/Controllers/SprintsController.php
+++ b/app/Http/Controllers/SprintsController.php
@@ -67,4 +67,17 @@ class SprintsController extends Controller {
 		Flash::success('The sprint settings have been updated');
 		return Redirect::back();
 	}
+
+	public function delete(Sprint $sprint)
+	{
+		if ($sprint->delete())
+		{
+			Flash::success('The sprint was deleted.');
+			return Redirect::route('project_path', ['project' => $sprint->project->slug]);
+		} else
+		{
+			Flash::error('The sprint could not be deleted. Please try again.');
+			return Redirect::back();
+		}
+	}
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -28,6 +28,7 @@ class Kernel extends HttpKernel {
 		'auth' => 'App\Http\Middleware\Authenticate',
 		'auth.basic' => 'Illuminate\Auth\Middleware\AuthenticateWithBasicAuth',
 		'guest' => 'App\Http\Middleware\RedirectIfAuthenticated',
+		'admin' => 'App\Http\Middleware\AuthenticateAdmin'
 	];
 
 }

--- a/app/Http/Middleware/AuthenticateAdmin.php
+++ b/app/Http/Middleware/AuthenticateAdmin.php
@@ -3,7 +3,7 @@
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
 
-class Authenticate {
+class AuthenticateAdmin {
 
 	/**
 	 * The Guard implementation.
@@ -32,7 +32,7 @@ class Authenticate {
 	 */
 	public function handle($request, Closure $next)
 	{
-		if ($this->auth->guest())
+		if (!$this->auth->user()->isInAdminList($_ENV['PHRAGILE_ADMINS']))
 		{
 			if ($request->ajax())
 			{

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -112,3 +112,9 @@ Route::put('sprints/{sprint}', [
 	'middleware' => 'auth',
 	'uses' => 'SprintsController@updateSettings'
 ]);
+
+Route::get('/sprints/{sprint}/delete', [ // should be a DELETE
+	'as' => 'delete_sprint_path',
+	'middleware' => 'auth',
+	'uses' => 'SprintsController@delete'
+]);

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -53,7 +53,7 @@ Route::get('/projects/{project}', [
 ]);
 
 Route::post('projects/store', [
-	'middleware' => 'auth',
+	'middleware' => 'admin',
 	'as' => 'create_project_path',
 	'uses' => 'ProjectsController@store'
 ]);
@@ -87,7 +87,7 @@ Route::get('/sprints/{sprint}/snapshot', [ // should technically be a POST
 
 Route::get('/snapshots/{snapshot}/delete', [ // should be a DELETE
 	'as' => 'delete_snapshot_path',
-	'middleware' => 'auth',
+	'middleware' => 'admin',
 	'uses' => 'SprintSnapshotsController@delete'
 ]);
 
@@ -115,6 +115,6 @@ Route::put('sprints/{sprint}', [
 
 Route::get('/sprints/{sprint}/delete', [ // should be a DELETE
 	'as' => 'delete_sprint_path',
-	'middleware' => 'auth',
+	'middleware' => 'admin',
 	'uses' => 'SprintsController@delete'
 ]);

--- a/resources/views/sprint/view.blade.php
+++ b/resources/views/sprint/view.blade.php
@@ -27,6 +27,19 @@
 					</li>
 				@endforeach
 			</ul>
+
+			@if(Auth::check())
+				{!! link_to_route(
+					'delete_sprint_path',
+					'',
+					['sprint' => $sprint->phabricator_id],
+					[
+						'class' => 'btn btn-danger btn-lg glyphicon glyphicon-remove',
+						'title' => 'Delete sprint',
+						'onclick' => 'return confirm("Delete this sprint?")'
+					]
+				) !!}
+			@endif
 		</span>
 
 		<a href="{{ $_ENV['PHABRICATOR_URL'] }}project/view/{{ $sprint->phabricator_id }}" class="btn btn-default" title="Go to Phabricator" target="_blank">

--- a/resources/views/sprint/view.blade.php
+++ b/resources/views/sprint/view.blade.php
@@ -28,7 +28,7 @@
 				@endforeach
 			</ul>
 
-			@if(Auth::check())
+			@if(Auth::check() && Auth::user()->isInAdminList($_ENV['PHRAGILE_ADMINS']))
 				{!! link_to_route(
 					'delete_sprint_path',
 					'',
@@ -88,7 +88,7 @@
 					</a>
 				@endif
 
-				@if(isset($snapshot) && Auth::check())
+				@if(isset($snapshot) && Auth::check() && Auth::user()->isInAdminList($_ENV['PHRAGILE_ADMINS']))
 					{!! link_to_route(
 						'delete_snapshot_path',
 						'',

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -459,4 +459,12 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	{
 		PHPUnit::assertCount(intval($number), $this->responseJSON()->$key);
 	}
+
+	/**
+	 * @Then the sprint :sprint should not exist
+	 */
+	public function theSprintShouldNotExist($sprint)
+	{
+		PHPUnit::assertNull(Sprint::where('title', $sprint)->first());
+	}
 }

--- a/tests/acceptance/sprint_overview.feature
+++ b/tests/acceptance/sprint_overview.feature
@@ -42,3 +42,10 @@ Feature: Sprint Overview
     And I should see "2014-12-06"
     And I should see "2014-12-07"
     And I should see "2014-12-08"
+
+  Scenario: Delete sprint
+    Given a sprint "Sprint 42" exists for the "Wikidata" project
+    And I am logged in
+    When I go to the "Sprint 42" sprint overview
+    And I click "Delete sprint"
+    Then the sprint "Sprint 42" should not exist


### PR DESCRIPTION
Fixes https://phabricator.wikimedia.org/T108295

In this version it is only checked that the user is logged in. Further checks if the user is allowed to delete the sprint should be added in another pull request.

Strangely, the acceptance tests all fail on my machine so perhaps someone should run my new test before merging this :-)