### PR TITLE
Adjust acceptance tests after having the way of generating sprint snapshots

### DIFF
--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -412,11 +412,15 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	 */
 	public function iShouldHaveCreatedOneSnapshotForEachSprint()
 	{
-		$numberOfSprints = Sprint::count();
+		$numberOfActiveSprints = count(array_filter(Sprint::all()->all(), function($sprint)
+			{
+				return $sprint->isActive();
+			}
+		));
 
-		PHPUnit::assertSame($this->numberOfSnapshots + $numberOfSprints, SprintSnapshot::count());
+		PHPUnit::assertSame($this->numberOfSnapshots + $numberOfActiveSprints, SprintSnapshot::count());
 
-		SprintSnapshot::take($numberOfSprints)->delete(); // cleaning up
+		SprintSnapshot::take($numberOfActiveSprints)->delete(); // cleaning up
 	}
 
 	/**


### PR DESCRIPTION
Since https://github.com/wmde/phragile/commit/97c6f52560bdcbe30b9c424a2ad035a3986cb87c Artisan's `snapshots:create` command is generating snapshots for active sprints only.
This should be also considered in the acceptance test.