### PR TITLE
Add proper permission checking

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -28,6 +28,7 @@ class Kernel extends HttpKernel {
 		'auth' => 'App\Http\Middleware\Authenticate',
 		'auth.basic' => 'Illuminate\Auth\Middleware\AuthenticateWithBasicAuth',
 		'guest' => 'App\Http\Middleware\RedirectIfAuthenticated',
+		'admin' => 'App\Http\Middleware\AuthenticateAdmin'
 	];
 
 }

--- a/app/Http/Middleware/AuthenticateAdmin.php
+++ b/app/Http/Middleware/AuthenticateAdmin.php
@@ -3,7 +3,7 @@
 use Closure;
 use Illuminate\Contracts\Auth\Guard;
 
-class Authenticate {
+class AuthenticateAdmin {
 
 	/**
 	 * The Guard implementation.
@@ -32,7 +32,7 @@ class Authenticate {
 	 */
 	public function handle($request, Closure $next)
 	{
-		if ($this->auth->guest())
+		if (!$this->auth->user()->isInAdminList($_ENV['PHRAGILE_ADMINS']))
 		{
 			if ($request->ajax())
 			{

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -53,7 +53,7 @@ Route::get('/projects/{project}', [
 ]);
 
 Route::post('projects/store', [
-	'middleware' => 'auth',
+	'middleware' => 'admin',
 	'as' => 'create_project_path',
 	'uses' => 'ProjectsController@store'
 ]);
@@ -87,7 +87,7 @@ Route::get('/sprints/{sprint}/snapshot', [ // should technically be a POST
 
 Route::get('/snapshots/{snapshot}/delete', [ // should be a DELETE
 	'as' => 'delete_snapshot_path',
-	'middleware' => 'auth',
+	'middleware' => 'admin',
 	'uses' => 'SprintSnapshotsController@delete'
 ]);
 
@@ -115,6 +115,6 @@ Route::put('sprints/{sprint}', [
 
 Route::get('/sprints/{sprint}/delete', [ // should be a DELETE
 	'as' => 'delete_sprint_path',
-	'middleware' => 'auth',
+	'middleware' => 'admin',
 	'uses' => 'SprintsController@delete'
 ]);

--- a/resources/views/sprint/view.blade.php
+++ b/resources/views/sprint/view.blade.php
@@ -28,7 +28,7 @@
 				@endforeach
 			</ul>
 
-			@if(Auth::check())
+			@if(Auth::check() && Auth::user()->isInAdminList($_ENV['PHRAGILE_ADMINS']))
 				{!! link_to_route(
 					'delete_sprint_path',
 					'',
@@ -88,7 +88,7 @@
 					</a>
 				@endif
 
-				@if(isset($snapshot) && Auth::check())
+				@if(isset($snapshot) && Auth::check() && Auth::user()->isInAdminList($_ENV['PHRAGILE_ADMINS']))
 					{!! link_to_route(
 						'delete_snapshot_path',
 						'',


### PR DESCRIPTION
Only admins should be able to delete sprints and snapshots.

This is a follow-up to #135. Note that in the current state, the buttons are only visible to admins but everyone can still access the url to delete a sprint.