### PR TITLE
Sprint not found

### DIFF
--- a/app/Http/Controllers/SprintsController.php
+++ b/app/Http/Controllers/SprintsController.php
@@ -87,7 +87,7 @@ class SprintsController extends Controller {
 	private function sprintNotFound($sprintPhabricatorId)
 	{
 		$actionHandler = Phragile::getGlobalInstance()->newSprintNotFoundActionHandler();
-		return $actionHandler->performAction($sprintPhabricatorId);
+		return $actionHandler->performAction($sprintPhabricatorId, Auth::check());
 	}
 
 	public function connect()

--- a/app/Http/Controllers/SprintsController.php
+++ b/app/Http/Controllers/SprintsController.php
@@ -75,10 +75,12 @@ class SprintsController extends Controller {
 
 	public function delete(Sprint $sprint)
 	{
-		if ($sprint->delete()) {
+		if ($sprint->delete())
+		{
 			Flash::success('The sprint was deleted.');
 			return Redirect::route('project_path', ['project' => $sprint->project->slug]);
-		} else {
+		} else
+		{
 			Flash::error('The sprint could not be deleted. Please try again.');
 			return Redirect::back();
 		}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -119,7 +119,7 @@ Route::get('/sprints/{sprint}/delete', [ // should be a DELETE
 	'uses' => 'SprintsController@delete'
 ]);
 
-Route::post('sprints', [
+Route::post('sprints/connect', [
 	'as' => 'connect_sprint_path',
 	'middleware' => 'auth',
 	'uses' => 'SprintsController@connect'

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -18,7 +18,7 @@ Route::bind('project', function($slug)
 
 Route::bind('sprint', function($phabricatorID)
 {
-	return Sprint::where('phabricator_id', $phabricatorID)->first();
+	return Sprint::where('phabricator_id', $phabricatorID)->first() ?: new Sprint(['phabricator_id' => $phabricatorID]);
 });
 
 Route::bind('snapshot', function($snapshotID)

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -118,3 +118,9 @@ Route::get('/sprints/{sprint}/delete', [ // should be a DELETE
 	'middleware' => 'admin',
 	'uses' => 'SprintsController@delete'
 ]);
+
+Route::post('sprints', [
+	'as' => 'connect_sprint_path',
+	'middleware' => 'auth',
+	'uses' => 'SprintsController@connect'
+]);

--- a/app/Phragile/ActionHandler/SprintNotFoundActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintNotFoundActionHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phragile\ActionHandler;
+
+use Phragile\PhabricatorAPI;
+use Sprint;
+
+class SprintNotFoundActionHandler {
+	private $phabricatorAPI;
+
+	public function __construct(PhabricatorAPI $phabricatorAPI)
+	{
+		$this->phabricatorAPI = $phabricatorAPI;
+	}
+
+	public function performAction($sprintPhabricatorId)
+	{
+		$phabricatorProject = $this->phabricatorAPI->queryProjectByID($sprintPhabricatorId);
+		if (!$phabricatorProject)
+		{
+			return \View::make('sprint.not_found');
+		}
+
+		$duration = $this->phabricatorAPI->getSprintDuration($phabricatorProject['phid']);
+
+		return \View::make('sprint.connect', [
+			'duration' => $duration,
+			'phabricatorProject' => $phabricatorProject,
+			'projects' => $this->getProjects(),
+		]);
+	}
+
+	private function getProjects()
+	{
+		$projects = [];
+		foreach (\Project::orderBy('title', 'ASC')->get() as $project)
+		{
+			$projects[$project['id']] = $project['title'];
+		}
+
+		return $projects;
+	}
+}

--- a/app/Phragile/ActionHandler/SprintNotFoundActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintNotFoundActionHandler.php
@@ -13,12 +13,16 @@ class SprintNotFoundActionHandler {
 		$this->phabricatorAPI = $phabricatorAPI;
 	}
 
-	public function performAction($sprintPhabricatorId)
+	public function performAction($sprintPhabricatorId, $isLoggedIn)
 	{
 		$phabricatorProject = $this->phabricatorAPI->queryProjectByID($sprintPhabricatorId);
 		if (!$phabricatorProject)
 		{
 			return \View::make('sprint.not_found');
+		}
+		if (!$isLoggedIn)
+		{
+			return \View::make('sprint.connect_unauthorized', ['phabricatorProject' => $phabricatorProject]);
 		}
 
 		$duration = $this->phabricatorAPI->getSprintDuration($phabricatorProject['phid']);

--- a/app/Phragile/PhabricatorAPI.php
+++ b/app/Phragile/PhabricatorAPI.php
@@ -116,4 +116,23 @@ class PhabricatorAPI {
 			['phids' => $phids]
 		);
 	}
+
+	public function getSprintDuration($phid)
+	{
+		try
+		{
+			$duration = $this->client->callMethodSynchronous(
+				'sprint.getstartenddates',
+				['project' => $phid]
+			);
+
+			return array_map(function($date)
+			{
+				return date('Y-m-d', $date);
+			}, $duration);
+		} catch (\ConduitClientException $e)
+		{
+			return null;
+		}
+	}
 }

--- a/app/Phragile/Phragile.php
+++ b/app/Phragile/Phragile.php
@@ -3,6 +3,7 @@ namespace Phragile;
 
 use App;
 use Phragile\ActionHandler\SprintLiveDataActionHandler;
+use Phragile\ActionHandler\SprintNotFoundActionHandler;
 use Phragile\ActionHandler\SprintStoreActionHandler;
 use \ConduitClient;
 
@@ -27,5 +28,10 @@ class Phragile {
 			new PhabricatorAPI(new ConduitClient($_ENV['PHABRICATOR_URL'])),
 			App::make('phabricator')
 		);
+	}
+
+	public function newSprintNotFoundActionHandler()
+	{
+		return new SprintNotFoundActionHandler(App::make('phabricator'));
 	}
 }

--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -25,7 +25,7 @@
 								]
 							) !!}
 						</li>
-						@if(in_array(Route::currentRouteName(), ['project_path', 'sprint_path', 'sprint_live_path', 'snapshot_path']))
+						@if(in_array(Route::currentRouteName(), ['project_path', 'sprint_path', 'sprint_live_path', 'snapshot_path']) && isset($sprint))
 							<li>{!! link_to_route('create_sprint_path', 'New sprint', isset($project) ? $project->slug : $sprint->project->slug) !!}</li>
 							<li><a id="project-settings" href="#" data-toggle="modal" data-target="#project-settings-modal">Project settings</a></li>
 							<li><a id="sprint-settings" href="#" data-toggle="modal" data-target="#sprint-settings-modal">Sprint settings</a></li>

--- a/resources/views/sprint/connect.blade.php
+++ b/resources/views/sprint/connect.blade.php
@@ -19,7 +19,7 @@
 
         @if($duration)
             {!! Form::text('sprint_start', $duration['start'], ['class' => 'hidden']) !!}
-            {!! Form::text('sprint_start', $duration['end'], ['class' => 'hidden']) !!}
+            {!! Form::text('sprint_end', $duration['end'], ['class' => 'hidden']) !!}
         @else
             <div class="form-group">
                 {!! Form::label('sprint_start', 'Sprint start:') !!}

--- a/resources/views/sprint/connect.blade.php
+++ b/resources/views/sprint/connect.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.default')
+
+@section('title', 'Connect existing Phabricator project')
+
+@section('content')
+    <h1>Connect with Phragile</h1>
+    <p>
+        The sprint "{{ $phabricatorProject['name'] }}" exists on Phabricator but not on Phragile.
+        You can use the following form to connect it with Phragile.
+    </p>
+
+    {!! Form::open(['method' => 'POST', 'route' => ['connect_sprint_path']]) !!}
+        {!! Form::text('title', $phabricatorProject['id'], ['class' => 'hidden']) !!}
+
+        <div class="form-group">
+            {!! Form::label('project', 'Project') !!}
+            {!! Form::select('project', $projects) !!}
+        </div>
+
+        @if($duration)
+            {!! Form::text('sprint_start', $duration['start'], ['class' => 'hidden']) !!}
+            {!! Form::text('sprint_start', $duration['end'], ['class' => 'hidden']) !!}
+        @else
+            <div class="form-group">
+                {!! Form::label('sprint_start', 'Sprint start:') !!}
+                {!! Form::text('sprint_start', '', ['class' => 'form-control datepicker start']) !!}
+            </div>
+
+            <div class="form-group">
+                {!! Form::label('sprint_end', 'Sprint end:') !!}
+                {!! Form::text('sprint_end', '', ['class' => 'form-control datepicker end']) !!}
+            </div>
+        @endif
+
+        {!! Form::submit('Connect this sprint with Phragile', ['class' => 'btn btn-primary']) !!}
+    {!! Form::close() !!}
+@stop
+
+@include('sprint.partials.datepicker_assets')

--- a/resources/views/sprint/connect.blade.php
+++ b/resources/views/sprint/connect.blade.php
@@ -13,8 +13,8 @@
         {!! Form::text('title', $phabricatorProject['id'], ['class' => 'hidden']) !!}
 
         <div class="form-group">
-            {!! Form::label('project', 'Project') !!}
-            {!! Form::select('project', $projects) !!}
+            {!! Form::label('project', 'Project:') !!}
+            {!! Form::select('project', $projects, ['class' => 'form-control']) !!}
         </div>
 
         @if($duration)

--- a/resources/views/sprint/connect_unauthorized.blade.php
+++ b/resources/views/sprint/connect_unauthorized.blade.php
@@ -1,0 +1,11 @@
+@extends('layouts.default')
+
+@section('title', 'Connect existing Phabricator project')
+
+@section('content')
+    <h1>Connect with Phragile</h1>
+    <p>
+        The sprint "{{ $phabricatorProject['name'] }}" exists on Phabricator but not on Phragile.
+        Please log in to connect the sprint with Phragile.
+    </p>
+@stop

--- a/resources/views/sprint/not_found.blade.php
+++ b/resources/views/sprint/not_found.blade.php
@@ -1,0 +1,10 @@
+@extends('layouts.default')
+
+@section('title', 'Connect existing Phabricator project')
+
+@section('content')
+    <h1>Sprint not found</h1>
+    <p>
+        Unfortunately the sprint you are looking for exists neither in Phragile nor in Phabricator.
+    </p>
+@stop

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -197,6 +197,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 				throw new Exception('There was a problem creating the sprint.' . $newSprint->getPhabricatorError());
 			}
 		}
+		$this->phabricatorProjectID = $existingSprint ? $existingSprint->phabricator_id : $newSprint->phabricator_id;
 	}
 
 	/**
@@ -494,4 +495,12 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		$this->iGoToTheLatestSnapshotPageOf($sprint);
 		$this->assertPageContainsText('#' . $this->selectedTask['id'] . ' ');
 	}
+
+    /**
+     * @When I go to the sprint overview of the missing sprint
+     */
+    public function iGoToTheSprintOverviewOfTheMissingSprint()
+    {
+        $this->visit("/sprints/$this->phabricatorProjectID");
+    }
 }

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -496,11 +496,11 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		$this->assertPageContainsText('#' . $this->selectedTask['id'] . ' ');
 	}
 
-    /**
-     * @When I go to the sprint overview of the missing sprint
-     */
-    public function iGoToTheSprintOverviewOfTheMissingSprint()
-    {
-        $this->visit("/sprints/$this->phabricatorProjectID");
-    }
+	/**
+	 * @When I go to the sprint overview of the missing sprint
+	 */
+	public function iGoToTheSprintOverviewOfTheMissingSprint()
+	{
+		$this->visit("/sprints/$this->phabricatorProjectID");
+	}
 }

--- a/tests/acceptance/unknown_sprint.feature
+++ b/tests/acceptance/unknown_sprint.feature
@@ -13,6 +13,12 @@ Feature: Unknown Sprint Page
     And I press "Connect this sprint with Phragile"
     Then I should see "Connected \"Test Sprint\" with an existing Phabricator project"
 
+  Scenario: Not logged in
+    Given I am not logged in
+    And a sprint "Test Sprint" exists for the "Wikidata" project in Phabricator but not in Phragile
+    When I go to the sprint overview of the missing sprint
+    Then I should see "Please log in to connect the sprint with Phragile."
+
   Scenario: Sprint exists neither in Phabricator nor Phragile
     Given I am on "/sprints/99999999"
     Then I should see "Sprint not found"

--- a/tests/acceptance/unknown_sprint.feature
+++ b/tests/acceptance/unknown_sprint.feature
@@ -1,0 +1,18 @@
+Feature: Unknown Sprint Page
+  In order to easily connect an existing Phabricator sprint with Phragile
+  As a user
+  I want to see a page that allows me to instantly create that sprint on Phragile when I go to a sprint page that Phragile does not know about yet.
+
+  Scenario: Sprint exists in Phabricator but not in Phragile
+    Given I am logged in
+    And a sprint "Test Sprint" exists for the "Wikidata" project in Phabricator but not in Phragile
+    When I go to the sprint overview of the missing sprint
+    And I select "Wikidata" from "project"
+    And I fill in "sprint_start" with "2015-08-08"
+    And I fill in "sprint_end" with "2015-08-22"
+    And I press "Connect this sprint with Phragile"
+    Then I should see "Connected \"Test Sprint\" with an existing Phabricator project"
+
+  Scenario: Sprint exists neither in Phabricator nor Phragile
+    Given I am on "/sprints/99999999"
+    Then I should see "Sprint not found"


### PR DESCRIPTION
This solves https://phabricator.wikimedia.org/T104455

When a sprint exists neither on Phabricator nor on Phragile, you now get an error page.
If the sprint exists on Phabricator but not on Phragile you get a form to fill in the project (and start and end date when not using the sprint extension) which makes it easy to connect existing Phabricator project with Phragile.