### PR TITLE
Fix sprint exists step in behat tests.

### DIFF
--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -251,23 +251,6 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	}
 
 	/**
-	 * @When I remove task :taskID from all projects
-	 */
-	public function iRemoveTaskFrom($taskID)
-	{
-		App::make('phabricator')->updateTask($taskID, ['projectPHIDs' => []]);
-	}
-
-	/**
-	 * @Then I should see :text in the latest :sprint snapshot
-	 */
-	public function iShouldSeeInTheLatestSnapshot($text, $sprint)
-	{
-		$this->iGoToTheLatestSnapshotPageOf($sprint);
-		$this->assertResponseContains($text);
-	}
-
-	/**
 	 * @When I go to the :sprint live page
 	 */
 	public function iGoToTheSprintLivePage($sprint)
@@ -485,5 +468,30 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	public function iShouldSeeMyNameInTheTaskSRowOfTheSprintBacklog()
 	{
 		$this->assertElementContains('#t' . $this->selectedTask['id'], $this->params['phabricator_username']);
+	}
+
+	/**
+	 * @When the selected task is removed from all projects
+	 */
+	public function theSelectedTaskIsRemovedFromAllProjects()
+	{
+		App::make('phabricator')->updateTask($this->selectedTask['id'], ['projectPHIDs' => []]);
+	}
+
+	/**
+	 * @Then I should not see the selected task
+	 */
+	public function iShouldNotSeeTheSelectedTask()
+	{
+		$this->assertPageNotContainsText('#' . $this->selectedTask['id'] . ' ');
+	}
+
+	/**
+	 * @Then I should see the selected in the latest :sprint snapshot
+	 */
+	public function iShouldSeeTheSelectedInTheLatestSnapshot($sprint)
+	{
+		$this->iGoToTheLatestSnapshotPageOf($sprint);
+		$this->assertPageContainsText('#' . $this->selectedTask['id'] . ' ');
 	}
 }

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -164,6 +164,11 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		}
 	}
 
+	private function getPhabricatorProjectFromTitle($title)
+	{
+		return App::make('phabricator')->queryProjectByTitle($title);
+	}
+
 	/**
 	 * @Given a sprint :sprint exists for the :project project
 	 */
@@ -176,14 +181,17 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 
 		if (!$existingSprint)
 		{
+			$phabricatorProject = $this->getPhabricatorProjectFromTitle($sprintTitle);
 			$newSprint = new Sprint([
 				'title' => $sprintTitle,
 				'project_id' => $project->id,
 				'sprint_start' => '2014-12-01',
-				'sprint_end' => '2014-12-14'
+				'sprint_end' => '2014-12-14',
+				'phabricator_id' => $phabricatorProject['id'],
+				'phid' => $phabricatorProject['phid'],
 			]);
 
-			if (!$newSprint->save())
+			if (!$phabricatorProject || !$newSprint->save())
 			{
 				throw new Exception('There was a problem creating the sprint.' . $newSprint->getPhabricatorError());
 			}

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -13,6 +13,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 {
 	private $params;
 	private $phabricatorProjectID;
+	private $selectedTask;
 
 	public function __construct(array $params)
 	{
@@ -250,19 +251,6 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	}
 
 	/**
-	 * @Given :sprint contains task :taskID
-	 */
-	public function containsTask($sprint, $taskID)
-	{
-		App::make('phabricator')->updateTask(
-			$taskID,
-			[
-				'projectPHIDs' => [Sprint::where(['title' => $sprint])->first()->phid]
-			]
-		);
-	}
-
-	/**
 	 * @When I remove task :taskID from all projects
 	 */
 	public function iRemoveTaskFrom($taskID)
@@ -332,25 +320,6 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	public function theProjectDoesNotExist($project)
 	{
 		Project::where('title', $project)->delete();
-	}
-
-	/**
-	 * @When I am assigned to task :task
-	 */
-	public function iAmAssignedToTask($task)
-	{
-		App::make('phabricator')->updateTask(
-			$task,
-			['ownerPHID' => User::where('username', $this->params['phabricator_username'])->first()->phid]
-		);
-	}
-
-	/**
-	 * @Then I should see my name in the task :task row of the sprint backlog
-	 */
-	public function iShouldSeeMyNameInTheTaskRowOfTheSprintBacklog($task)
-	{
-		$this->assertElementContains("#t$task", $this->params['phabricator_username']);
 	}
 
 	/**
@@ -474,5 +443,47 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	public function theSprintShouldNotExist($sprint)
 	{
 		PHPUnit::assertNull(Sprint::where('title', $sprint)->first());
+	}
+
+	/**
+	 * @Given :sprint contains a task
+	 */
+	public function containsATask($sprintTitle)
+	{
+		$phid = Sprint::where('title', $sprintTitle)->first()->phid;
+		$this->selectedTask = $this->getOrCreateTaskForSprint($phid);
+	}
+
+	private function getOrCreateTaskForSprint($sprintPHID)
+	{
+		$phabricator = App::make('phabricator');
+		$tasks = $phabricator->queryTasksByProject($sprintPHID);
+
+		if ($tasks) return array_values($tasks)[0];
+
+		return $phabricator->createTask($sprintPHID, [
+			'title' => 'automated test task',
+			'priority' => 'high',
+			'points' => 1,
+		]);
+	}
+
+	/**
+	 * @When I am assigned to this task
+	 */
+	public function iAmAssignedToThisTask()
+	{
+		App::make('phabricator')->updateTask(
+			$this->selectedTask['id'],
+			['ownerPHID' => User::where('username', $this->params['phabricator_username'])->first()->phid]
+		);
+	}
+
+	/**
+	 * @Then I should see my name in the task's row of the sprint backlog
+	 */
+	public function iShouldSeeMyNameInTheTaskSRowOfTheSprintBacklog()
+	{
+		$this->assertElementContains('#t' . $this->selectedTask['id'], $this->params['phabricator_username']);
 	}
 }

--- a/tests/acceptance/sprint_overview.feature
+++ b/tests/acceptance/sprint_overview.feature
@@ -18,11 +18,11 @@ Feature: Sprint Overview
     And I should see "8"
 
   Scenario: Assignees in Sprint Backlog
-    Given a sprint "Sprint 42" exists for the "Wikidata" project
-    And "Sprint 42" contains task "113"
-    When I am assigned to task "113"
-    And I go to the "Sprint 42" sprint overview
-    Then I should see my name in the task "113" row of the sprint backlog
+    Given a sprint "Wikidata Sprint 42" exists for the "Wikidata" project
+    And "Wikidata Sprint 42" contains a task
+    When I am assigned to this task
+    And I go to the "Wikidata Sprint 42" sprint overview
+    Then I should see my name in the task's row of the sprint backlog
 
   Scenario: Sprint duration
     Given a sprint "Sprint 42" exists for the "Wikidata" project

--- a/tests/acceptance/sprint_snapshots.feature
+++ b/tests/acceptance/sprint_snapshots.feature
@@ -11,12 +11,12 @@ Feature: Sprint Snapshots
 
   Scenario: Snapshots are not affected by Phabricator actions
     Given a sprint "Sprint 42" exists for the "Wikidata" project
-    And "Sprint 42" contains task "113"
+    And "Sprint 42" contains a task
     When I create a sprint snapshot for "Sprint 42"
-    And I remove task "113" from all projects
-    When I go to the "Sprint 42" sprint overview
-    Then I should not see "T113"
-    But I should see "T113" in the latest "Sprint 42" snapshot
+    And the selected task is removed from all projects
+    When I go to the "Sprint 42" live page
+    Then I should not see the selected task
+    But I should see the selected in the latest "Sprint 42" snapshot
 
   Scenario: Create new snapshot
     Given a sprint "Sprint 42" exists for the "Wikidata" project


### PR DESCRIPTION
Before this fix sprints were missing the `phid` and `phabricator_id` whenever they got deleted and re-added by the behat tests. This fixes the issue by fetching the missing attributes from Phabricator.