### PR TITLE
Fix scenario 'Assignees in Sprint Backlog'.

### DIFF
--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -461,7 +461,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 
 		if ($tasks) return array_values($tasks)[0];
 
-		return $phabricator->createTask($phid, [
+		return $phabricator->createTask($sprintPHID, [
 			'title' => 'automated test task',
 			'priority' => 'high',
 			'points' => 1,

--- a/tests/acceptance/sprint_overview.feature
+++ b/tests/acceptance/sprint_overview.feature
@@ -18,11 +18,11 @@ Feature: Sprint Overview
     And I should see "8"
 
   Scenario: Assignees in Sprint Backlog
-    Given a sprint "Sprint 42" exists for the "Wikidata" project
-    And "Sprint 42" contains task "113"
-    When I am assigned to task "113"
-    And I go to the "Sprint 42" sprint overview
-    Then I should see my name in the task "113" row of the sprint backlog
+    Given a sprint "Wikidata Sprint 42" exists for the "Wikidata" project
+    And "Wikidata Sprint 42" contains a task
+    When I am assigned to this task
+    And I go to the "Wikidata Sprint 42" sprint overview
+    Then I should see my name in the task's row of the sprint backlog
 
   Scenario: Sprint duration
     Given a sprint "Sprint 42" exists for the "Wikidata" project


### PR DESCRIPTION
This fixes a scenario that previously always failed. It contained a hardcoded task ID which is now replaced. The fix introduces some state flying around in `FeatureContext` which isn't great but having the tests pass is more valuable in my opinion.
There is another scenario failing because of this which I will fix in a separate pull request.

Poke @wmde-manicki @Benestar 