### PR TITLE
Fix sprint exists step

### DIFF
--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -178,7 +178,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		Auth::login(User::where('username', $this->params['phabricator_username'])->first()); // this is a bit ugly.
 
 		$project = Project::firstOrCreate(['title' => $projectTitle]);
-		$phabricatorProject = $this->getPhabricatorProjectFromTitle($sprintTitle);
+		$phabricatorProject = $this->getPhabricatorProjectFromTitle($sprintTitle) ?: $this->createPhabricatorProject($sprintTitle);
 		$existingSprint = Sprint::where('phid', $phabricatorProject['phid'])->first();
 
 		if ($existingSprint !== null && !$existingSprint->delete())
@@ -199,6 +199,11 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		{
 			throw new Exception('There was a problem creating the sprint.' . $newSprint->getPhabricatorError());
 		}
+	}
+
+	private function createPhabricatorProject($sprintTitle)
+	{
+		return App::make('phabricator')->createProject($sprintTitle, []);
 	}
 
 	/**


### PR DESCRIPTION
The `@Given a sprint :sprint exists for the :project project` step should create a corresponding Phabricator project for the created sprint if it does not exist yet.

This fixes the issue in #145