### PR TITLE
Lazy load snapshot data

### DIFF
--- a/app/Http/Controllers/SprintSnapshotsController.php
+++ b/app/Http/Controllers/SprintSnapshotsController.php
@@ -54,7 +54,7 @@ class SprintSnapshotsController extends Controller {
 
 	private function getSprintDataFactory(SprintSnapshot $snapshot)
 	{
-		$sprintData = json_decode($snapshot->data, true);
+		$sprintData = json_decode($snapshot->getData(), true);
 		return new SprintDataFactory(
 			$snapshot->sprint,
 			$sprintData['tasks'],

--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -22,7 +22,9 @@ class Sprint extends Eloquent {
 	 */
 	public function sprintSnapshots()
 	{
-		return $this->hasMany('SprintSnapshot')->orderBy('created_at', 'desc');
+		return $this->hasMany('SprintSnapshot')
+		            ->select(['id', 'sprint_id', 'created_at', 'total_points'])
+		            ->orderBy('created_at', 'desc');
 	}
 
 	public function validate()

--- a/app/Models/SprintSnapshot.php
+++ b/app/Models/SprintSnapshot.php
@@ -22,4 +22,9 @@ class SprintSnapshot extends Eloquent {
 	{
 		return $this->attributes['created_at'];
 	}
+
+	public function getData()
+	{
+		return $this->data ?: self::select('data')->find($this->id)->data;
+	}
 }

--- a/app/Models/SprintSnapshot.php
+++ b/app/Models/SprintSnapshot.php
@@ -25,6 +25,11 @@ class SprintSnapshot extends Eloquent {
 
 	public function getData()
 	{
-		return $this->data ?: self::select('data')->find($this->id)->data;
+		if ($this->data === null)
+		{
+			$this->data = self::find($this->id)->data;
+		}
+
+		return $this->data;
 	}
 }


### PR DESCRIPTION
Snapshots caused memory issues for large projects on sprint overviews since the entire snapshot including archived task and transaction data got loaded for each existing snapshot for the sprint.
This patch solves this by lazy-loading the snapshots' data attribute.

Fixes https://phabricator.wikimedia.org/T110649