### PR TITLE
Number of tasks in snapshots

### DIFF
--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -101,6 +101,7 @@ class Sprint extends Eloquent {
 			'sprint_id' => $this->id,
 			'data' => json_encode($this->fetchSnapshotData($tasks)),
 			'total_points' => $this->calculateTotalPoints($tasks),
+			'task_count' => count($tasks),
 		]);
 	}
 

--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -111,7 +111,7 @@ class Sprint extends Eloquent {
 			$tasks,
 			function($sum, $task)
 			{
-				return $sum + ($this->ignore_estimates ? 1 : $task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')]);
+				return $sum + $task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')];
 			},
 			0
 		);

--- a/app/Models/SprintSnapshot.php
+++ b/app/Models/SprintSnapshot.php
@@ -25,11 +25,18 @@ class SprintSnapshot extends Eloquent {
 
 	public function getData()
 	{
-		if ($this->data === null)
-		{
+		if ($this->data === null) {
 			$this->data = self::find($this->id)->data;
 		}
 
 		return $this->data;
+	}
+
+	/**
+	 * @return int - Number of story points or tasks depending on the sprint settings
+	 */
+	public function getScope()
+	{
+		return $this->sprint->ignore_estimates ? $this->task_count : $this->total_points;
 	}
 }

--- a/app/Models/SprintSnapshot.php
+++ b/app/Models/SprintSnapshot.php
@@ -1,7 +1,7 @@
 <?php
 
 class SprintSnapshot extends Eloquent {
-	protected $fillable =  ['data', 'sprint_id', 'created_at', 'total_points'];
+	protected $fillable =  ['data', 'sprint_id', 'created_at', 'total_points', 'task_count'];
 
 	/**
 	 * @return Sprint

--- a/app/Phragile/ScopeLine.php
+++ b/app/Phragile/ScopeLine.php
@@ -32,8 +32,8 @@ class ScopeLine {
 				$days[$day] = $this->pointsNumber;
 			} elseif (isset($this->snapshots[$day]))
 			{
-				$days[$day] = $this->snapshots[$day]->total_points;
-				$currentPoints = $this->snapshots[$day]->total_points;
+				$days[$day] = $this->snapshots[$day]->getScope();
+				$currentPoints = $this->snapshots[$day]->getScope();
 			} else
 			{
 				$days[$day] = $currentPoints;
@@ -47,7 +47,7 @@ class ScopeLine {
 	{
 		foreach ($this->dateRange as $date)
 		{
-			if (isset($this->snapshots[$date])) return $this->snapshots[$date]->total_points;
+			if (isset($this->snapshots[$date])) return $this->snapshots[$date]->getScope();
 		}
 
 		return $this->pointsNumber;

--- a/database/migrations/2015_09_03_093948_add_number_of_tasks_to_snapshots.php
+++ b/database/migrations/2015_09_03_093948_add_number_of_tasks_to_snapshots.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddNumberOfTasksToSnapshots extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('sprint_snapshots', function($t)
+		{
+			$t->integer('task_count');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('sprint_snapshots', function($t)
+		{
+			$t->dropColumn('task_count');
+		});
+	}
+
+}

--- a/tests/unit/ScopeLineTest.php
+++ b/tests/unit/ScopeLineTest.php
@@ -25,14 +25,8 @@ class ScopeLineTest extends TestCase {
 
 	public function testShouldAlwaysUseLastSnapshot()
 	{
-		$snapshot1 = new SprintSnapshot([
-			'total_points' => 42,
-		]);
-		$snapshot1->setCreatedAt('2015-01-01 00:00:00');
-		$snapshot2 = new SprintSnapshot([
-			'total_points' => 41,
-		]);
-		$snapshot2->setCreatedAt('2015-01-01 02:00:00');
+		$snapshot1 = $this->newSnapshot('2015-01-01 00:00:00', ['total_points' => 42]);
+		$snapshot2 = $this->newSnapshot('2015-01-01 02:00:00', ['total_points' => 41]);
 		$scopeLine = new ScopeLine([$snapshot1, $snapshot2], 43, ['2015-01-01']);
 
 		$data = $scopeLine->getData();
@@ -41,16 +35,22 @@ class ScopeLineTest extends TestCase {
 
 	public function testShouldFillTotalPointsBackwardsFromFirstSnapshot()
 	{
-		$snapshot = new SprintSnapshot([
-			'total_points' => 42,
-		]);
-		$snapshot->setCreatedAt('2015-01-02 00:00:00');
 		$duration = ['2015-01-01', '2015-01-02'];
+		$snapshot = $this->newSnapshot($duration[1], ['total_points' => 42]);
 		$scopeLine = new ScopeLine([$snapshot], 40, $duration);
 
 		$data = $scopeLine->getData();
 		$this->assertSame($data[$duration[0]], 42);
 		$this->assertSame($data[$duration[1]], 42);
+	}
+
+	public function newSnapshot($date, $fields, $sprint = null)
+	{
+		$snapshot = new SprintSnapshot($fields);
+		$snapshot->sprint = $sprint ?: new Sprint(['ignore_estimates' => false, 'title' => 'wat']);
+		$snapshot->setCreatedAt($date);
+
+		return $snapshot;
 	}
 
 	public function testShouldConsiderCurrentNumberOfStoryPoints()
@@ -64,10 +64,7 @@ class ScopeLineTest extends TestCase {
 			date($dateFormat, $currentTime),
 			date($dateFormat, $currentTime + $daySeconds),
 		];
-		$snapshot = new SprintSnapshot([
-			'total_points' => 42,
-		]);
-		$snapshot->setCreatedAt(date($dateFormat, $currentTime - $daySeconds));
+		$snapshot = $this->newSnapshot(date($dateFormat, $currentTime - $daySeconds), ['total_points' => 42]);
 		$scopeLine = new ScopeLine([$snapshot], 40, $duration);
 
 		$data = $scopeLine->getData();

--- a/tests/unit/ScopeLineTest.php
+++ b/tests/unit/ScopeLineTest.php
@@ -73,4 +73,17 @@ class ScopeLineTest extends TestCase {
 		$this->assertSame($data[$duration[2]], 40);
 		$this->assertSame($data[$duration[3]], 40);
 	}
+
+	public function testShouldUseTaskCountBasedOnSettings()
+	{
+		$sprint = new Sprint(['ignore_estimates' => true, 'title' => 'sup']);
+		$duration = ['2015-01-01', '2015-01-02'];
+		$s1 = $this->newSnapshot($duration[0], ['total_points' => 5, 'task_count' => 2], $sprint);
+		$s2 = $this->newSnapshot($duration[1], ['total_points' => 8, 'task_count' => 3], $sprint);
+
+		$scopeLine = new ScopeLine([$s1, $s2], 3, $duration);
+		$data = $scopeLine->getData();
+		$this->assertSame($data[$duration[0]], 2);
+		$this->assertSame($data[$duration[1]], 3);
+	}
 }


### PR DESCRIPTION
This fixes the issue that when switching `ignore_estimates` on or off after taking a snapshot, the scope line breaks since there is no differentiation between story points and task count with `ignore_estimates` enabled. To resolve that, snapshots now contain both the task count as well as the total number of story points in the sprint.

Fixes https://phabricator.wikimedia.org/T110892