### PR TITLE
Remove unneeded paragraph tag

### DIFF
--- a/resources/views/sprint/partials/settings_form.blade.php
+++ b/resources/views/sprint/partials/settings_form.blade.php
@@ -7,7 +7,6 @@
             </div>
             {!! Form::model($sprint, ['route' => ['sprint_settings_path', $sprint->phabricator_id], 'method' => 'PUT']) !!}
             <div class="modal-body">
-                <p>
                 <div class="form-group">
                     {!! Form::label('sprint_start', 'Sprint start:') !!}
                     {!! Form::text('sprint_start', $sprint->sprint_start, ['class' => 'form-control datepicker start']) !!}
@@ -29,7 +28,6 @@
                         Ignore story point estimates
                     </label>
                 </div>
-                </p>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
At least it looks in my Firefox that only thing this `<p>` tag does is adding some little space above the actual setting form but I guess this is not intentional