### PR TITLE
Ignore workboard columns

### DIFF
--- a/app/Http/Controllers/ProjectsController.php
+++ b/app/Http/Controllers/ProjectsController.php
@@ -43,7 +43,7 @@ class ProjectsController extends Controller {
 
 	public function updateSettings(Project $project)
 	{
-		$project->update(Input::only('closed_statuses', 'workboard_mode'));
+		$project->update(Input::only('closed_statuses', 'workboard_mode', 'ignored_columns'));
 
 		Flash::success('The project settings have been updated');
 		return Redirect::back();

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -2,7 +2,7 @@
 
 class Project extends Eloquent {
 
-	protected $fillable = ['title', 'slug', 'closed_statuses', 'workboard_mode'];
+	protected $fillable = ['title', 'slug', 'closed_statuses', 'workboard_mode', 'ignored_columns'];
 
 	/**
 	 * @return \Illuminate\Database\Eloquent\Collection
@@ -32,6 +32,11 @@ class Project extends Eloquent {
 	public function getClosedColumns()
 	{
 		return preg_split('/\s*,\s*/', $this->closed_statuses);
+	}
+
+	public function getIgnoredColumns()
+	{
+		return preg_split('/\s*,\s*/', $this->ignored_columns);
 	}
 
 	private function newestPastSprint()

--- a/app/Phragile/Factory/SprintDataFactory.php
+++ b/app/Phragile/Factory/SprintDataFactory.php
@@ -32,7 +32,7 @@ class SprintDataFactory {
 		$this->taskList = new TaskList(
 			$tasks,
 			(new StatusDispatcherFactory($sprint, $this->columns, $transactions))->getStatusDispatcher(),
-			$sprint->ignore_estimates
+			['ignore_estimates' => $sprint->ignore_estimates, 'ignored_columns' => $sprint->project->getIgnoredColumns()]
 		);
 
 		$this->burndownChart = $this->generateBurndownData();

--- a/app/Phragile/Factory/SprintDataFactory.php
+++ b/app/Phragile/Factory/SprintDataFactory.php
@@ -5,13 +5,10 @@ use Phragile\BurnupChart;
 use Phragile\ProjectColumnRepository;
 use Phragile\PhabricatorAPI;
 use Phragile\TaskList;
-use Phragile\StatusByStatusFieldDispatcher;
-use Phragile\StatusByWorkboardDispatcher;
 use Phragile\ClosedTimeByStatusFieldDispatcher;
 use Phragile\ClosedTimeByWorkboardDispatcher;
 use Phragile\AssigneeRepository;
 use Phragile\BurndownChart;
-use Phragile\TransactionList;
 use Phragile\ScopeLine;
 
 class SprintDataFactory {
@@ -31,12 +28,10 @@ class SprintDataFactory {
 		$this->transactions = $transactions;
 		$this->phabricatorAPI = $phabricatorAPI;
 
-		$this->columns = $this->fetchProjectColumns();
+		$this->columns = new ProjectColumnRepository($this->sprint->phid, $this->transactions, $this->phabricatorAPI);
 		$this->taskList = new TaskList(
 			$tasks,
-			$sprint->project->workboard_mode
-				? new StatusByWorkboardDispatcher($this->sprint->phid, new TransactionList($this->transactions), $this->columns, $this->getClosedColumns())
-				: new StatusByStatusFieldDispatcher(env('REVIEW_TAG_PHID')),
+			(new StatusDispatcherFactory($sprint, $this->columns, $transactions))->getStatusDispatcher(),
 			$sprint->ignore_estimates
 		);
 
@@ -130,10 +125,5 @@ class SprintDataFactory {
 	private function getClosedColumns()
 	{
 		return $this->sprint->project->getClosedColumns();
-	}
-
-	private function fetchProjectColumns()
-	{
-		return new ProjectColumnRepository($this->sprint->phid, $this->transactions, $this->phabricatorAPI);
 	}
 }

--- a/app/Phragile/Factory/StatusDispatcherFactory.php
+++ b/app/Phragile/Factory/StatusDispatcherFactory.php
@@ -1,0 +1,45 @@
+<?php
+namespace Phragile\Factory;
+
+use Phragile\ProjectColumnRepository;
+use Phragile\StatusDispatcher;
+use Phragile\StatusByStatusFieldDispatcher;
+use Phragile\StatusByWorkboardDispatcher;
+use Phragile\TransactionList;
+
+class StatusDispatcherFactory
+{
+	private $sprint = null;
+	private $projectColumnRepository = null;
+	private $transactions = [];
+
+	public function __construct(\Sprint $sprint, ProjectColumnRepository $projectColumnRepository, array $transactions)
+	{
+		$this->sprint = $sprint;
+		$this->projectColumnRepository = $projectColumnRepository;
+		$this->transactions = $transactions;
+	}
+
+	/**
+	 * @return StatusDispatcher
+	 */
+	public function getStatusDispatcher()
+	{
+		return $this->sprint->project->workboard_mode ? $this->getWorkboardDispatcher() : $this->getFieldDispatcher();
+	}
+
+	private function getWorkboardDispatcher()
+	{
+		return new StatusByWorkboardDispatcher(
+			$this->sprint->phid,
+			new TransactionList($this->transactions),
+			$this->projectColumnRepository,
+			$this->sprint->project->getClosedColumns()
+		);
+	}
+
+	private function getFieldDispatcher()
+	{
+		return new StatusByStatusFieldDispatcher(env('REVIEW_TAG_PHID'));
+	}
+}

--- a/app/Phragile/ProjectColumnRepository.php
+++ b/app/Phragile/ProjectColumnRepository.php
@@ -5,27 +5,38 @@ class ProjectColumnRepository {
 	/**
 	 * @var maps workboard column PHIDs to a map of column data
 	 */
-	private $projectColumns;
+	private $projectColumns = null;
+	private $transactions;
 	private $phabricator;
 	private $projectPHID;
 
 	public function __construct($projectPHID, array $transactions, PhabricatorAPI $phabricator)
 	{
 		$this->projectPHID = $projectPHID;
+		$this->transactions = $transactions;
 		$this->phabricator = $phabricator;
-		$this->projectColumns = $this->fetchColumnData($transactions);
 	}
 
 	public function getColumnName($phid)
 	{
+		$this->initialize();
 		return $phid ? $this->projectColumns[$phid]['name'] : null;
 	}
 
 	public function getColumnPHID($name)
 	{
+		$this->initialize();
 		foreach ($this->projectColumns as $phid => $column)
 		{
 			if ($column['name'] === $name) return $phid;
+		}
+	}
+
+	private function initialize()
+	{
+		if ($this->projectColumns === null)
+		{
+			$this->projectColumns = $this->fetchColumnData($this->transactions);
 		}
 	}
 

--- a/app/Phragile/TaskList.php
+++ b/app/Phragile/TaskList.php
@@ -10,9 +10,7 @@ class TaskList {
 	 * TaskList constructor.
 	 * @param array $phabricatorTaskData
 	 * @param StatusDispatcher $statusDispatcher
-	 * @param array $options
-	 * 		@option boolean "ignore_estimates"
-	 * 		@option array "ignored_columns"
+	 * @param array $options - (boolean) "ignore_estimates", (array) "ignored_columns"
 	 */
 	public function __construct(array $phabricatorTaskData, StatusDispatcher $statusDispatcher, array $options)
 	{

--- a/database/migrations/2016_01_08_154815_add_ignored_columns_to_project.php
+++ b/database/migrations/2016_01_08_154815_add_ignored_columns_to_project.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class AddIgnoredColumnsToProject extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('projects', function($t)
+		{
+			$t->string('ignored_columns');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('projects', function($t)
+		{
+			$t->dropColumn('ignored_columns');
+		});
+	}
+
+}

--- a/resources/views/project/partials/settings_form.blade.php
+++ b/resources/views/project/partials/settings_form.blade.php
@@ -21,6 +21,10 @@
                         {!! Form::label('closed_statuses', 'Closed status columns:') !!}
                         {!! Form::text('closed_statuses', $sprint->project->closed_statuses, ['class' => 'form-control']) !!}
                     </div>
+                    <div class="form-group form-inline">
+                        {!! Form::label('ignored_columns', 'Ignored workboard columns:') !!}
+                        {!! Form::text('ignored_columns', $sprint->project->ignored_columns, ['class' => 'form-control']) !!}
+                    </div>
                 </p>
             </div>
             <div class="modal-footer">

--- a/resources/views/project/partials/settings_form.blade.php
+++ b/resources/views/project/partials/settings_form.blade.php
@@ -17,11 +17,11 @@
                             Use workboards instead of statuses
                         </label>
                     </div>
-                    <div class="form-group form-inline closed_statuses">
+                    <div class="form-group form-inline workboard-related">
                         {!! Form::label('closed_statuses', 'Closed status columns:') !!}
                         {!! Form::text('closed_statuses', $sprint->project->closed_statuses, ['class' => 'form-control']) !!}
                     </div>
-                    <div class="form-group form-inline">
+                    <div class="form-group form-inline workboard-related">
                         {!! Form::label('ignored_columns', 'Ignored workboard columns:') !!}
                         {!! Form::text('ignored_columns', $sprint->project->ignored_columns, ['class' => 'form-control']) !!}
                     </div>
@@ -41,14 +41,14 @@
 
     <script type="text/javascript">
         if (!$('.workboard_mode input').is(':checked')) {
-            $('.closed_statuses').hide();
+            $('.workboard-related').hide();
         }
 
         $('.workboard_mode input').change(function() {
             if ($('.workboard_mode input').is(':checked')) {
-                $('.closed_statuses').slideDown('fast');
+                $('.workboard-related').slideDown('fast');
             } else {
-                $('.closed_statuses').slideUp('fast');
+                $('.workboard-related').slideUp('fast');
             }
         });
     </script>

--- a/tests/acceptance/workboard_support.feature
+++ b/tests/acceptance/workboard_support.feature
@@ -11,3 +11,10 @@ Feature: Workboard Support
     And I press "Save"
     Then the "workboard_mode" checkbox should be checked
     And the "closed_statuses" field should contain "Done, Deployed"
+
+  Scenario: Ignore workboard columns
+    Given I am logged in
+    And I am on the "Wikidata" project page
+    When I fill in "ignored_columns" with "Proposed, Ignore"
+    And I press "Save"
+    Then the "ignored_columns" field should contain "Proposed, Ignore"

--- a/tests/unit/TaskListTest.php
+++ b/tests/unit/TaskListTest.php
@@ -58,6 +58,18 @@ class TaskListTest extends TestCase {
 		$this->assertSame(10, $taskList->getTasksPerStatus()['to do']['points']);
 	}
 
+	public function testIgnoreToDoColumn()
+	{
+		$taskList = $this->createTaskListWithWorkboardDispatcher($this->tasks, $this->getProjectColumnTransactions(), []);
+		$taskListIgnore = $this->createTaskListWithWorkboardDispatcher($this->tasks, $this->getProjectColumnTransactions(), ['to do']);
+
+		$this->assertFalse(isset($taskListIgnore->getTasksPerStatus()['to do']['points']));
+		$this->assertSame(10, $taskList->getTasksPerStatus()['to do']['points']);
+
+		$this->assertSame(30, $taskList->getTasksPerStatus()['total']['points']);
+		$this->assertSame(20, $taskListIgnore->getTasksPerStatus()['total']['points']);
+	}
+
 	private $testProjectPHID = 'PHID-123';
 
 	private $tasks = [
@@ -146,7 +158,7 @@ class TaskListTest extends TestCase {
 		return new TaskList($tasks, new StatusByStatusFieldDispatcher('PHID-REVIEW123'), ['ignore_estimates' => true, 'ignored_columns' => []]);
 	}
 
-	private function createTaskListWithWorkboardDispatcher(array $tasks, $transactions)
+	private function createTaskListWithWorkboardDispatcher(array $tasks, $transactions, array $ignored_columns = [])
 	{
 		$phabricatorAPI = $this->getMockBuilder('Phragile\PhabricatorAPI')
 			->disableOriginalConstructor()
@@ -168,7 +180,7 @@ class TaskListTest extends TestCase {
 				new ProjectColumnRepository($this->testProjectPHID, $transactions, $phabricatorAPI),
 				array_values($this->workboardColumns)
 			),
-			['ignore_estimates' => false, 'ignored_columns' => []]
+			['ignore_estimates' => false, 'ignored_columns' => $ignored_columns]
 		);
 	}
 

--- a/tests/unit/TaskListTest.php
+++ b/tests/unit/TaskListTest.php
@@ -138,12 +138,12 @@ class TaskListTest extends TestCase {
 
 	private function createTaskListWithStatusFieldDispatcher(array $tasks)
 	{
-		return new TaskList($tasks, new StatusByStatusFieldDispatcher('PHID-REVIEW123'));
+		return new TaskList($tasks, new StatusByStatusFieldDispatcher('PHID-REVIEW123'), ['ignore_estimates' => false, 'ignored_columns' => []]);
 	}
 
 	private function createTaskListIgnoringEstimatesWithStatusFieldDispatcher(array $tasks)
 	{
-		return new TaskList($tasks, new StatusByStatusFieldDispatcher('PHID-REVIEW123'), true);
+		return new TaskList($tasks, new StatusByStatusFieldDispatcher('PHID-REVIEW123'), ['ignore_estimates' => true, 'ignored_columns' => []]);
 	}
 
 	private function createTaskListWithWorkboardDispatcher(array $tasks, $transactions)
@@ -160,12 +160,16 @@ class TaskListTest extends TestCase {
 			}, $this->workboardColumns);
 		}));
 
-		return new TaskList($tasks, new StatusByWorkboardDispatcher(
-			$this->testProjectPHID,
-			new TransactionList($transactions),
-			new ProjectColumnRepository($this->testProjectPHID, $transactions, $phabricatorAPI),
-			array_values($this->workboardColumns)
-		));
+		return new TaskList(
+			$tasks,
+			new StatusByWorkboardDispatcher(
+				$this->testProjectPHID,
+				new TransactionList($transactions),
+				new ProjectColumnRepository($this->testProjectPHID, $transactions, $phabricatorAPI),
+				array_values($this->workboardColumns)
+			),
+			['ignore_estimates' => false, 'ignored_columns' => []]
+		);
 	}
 
 	private function addDummyDataToTasks()


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T113716

Ignoring columns for snapshots got a little bit tricky since tasks did not know their status at the time the snapshot was created until now. I created a `StatusDispatcherFactory` to get the task status depending on a sprint's `workboard_mode` in both the `SprintDataFactory` and in during snapshot creation.