### PR TITLE
added new error message when connecting to existing project

### DIFF
--- a/app/Phragile/ActionHandler/SprintStoreActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintStoreActionHandler.php
@@ -101,7 +101,7 @@ class SprintStoreActionHandler {
 
 	private function connectIfPhabricatorProjectExists($errorMessage)
 	{
-		if (str_contains($errorMessage, 'Project name is already used'))
+		if (str_contains($errorMessage, ['Project name is already used', 'Project name generates the same hashtag']))
 		{
 			$this->connectWithPhabricatorProject();
 		} else $this->redirectBackWithError('Could not create a Phabricator project for this sprint.');


### PR DESCRIPTION
In the current stable versions of Phabricator and libphutil a new error appears when trying to add an existing project. 

`ERR-CONDUIT-CORE: Validation errors: - Project name generates the same hashtag ("#test_sprint") as another existing project. Choose a unique name.`