### PR TITLE
Bump version of the custom libphutil library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,7 @@
 					"url": "https://github.com/jakobw/libphutil/archive/master.zip",
 					"type": "zip"
 				},
-				"source": {
-					"url": "https://github.com/jakobw/libphutil.git",
-					"type": "git",
-					"reference": "master"
-				},
-				"version": "1.0"
+				"version": "1.1"
 			}
 		}
 	],
@@ -30,7 +25,7 @@
 		"laracasts/flash": "~1.0",
 		"guzzlehttp/guzzle": "~4.2",
 		"doctrine/dbal": "~2.4",
-		"libphutil": "1.0"
+		"libphutil": "1.1"
 	},
 	"require-dev": {
 		"behat/behat": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6639061b3465a3ee8dcdf03c19fb0e51",
-    "content-hash": "80b6bd0e663734d0cbb78a299cfa93df",
+    "hash": "cc1d19da72c2acf0f4d1aafb8da28dd2",
+    "content-hash": "9d05867214070cd9dbe34e3a7c21f82b",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -1231,12 +1231,7 @@
         },
         {
             "name": "libphutil",
-            "version": "1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jakobw/libphutil.git",
-                "reference": "master"
-            },
+            "version": "1.1",
             "dist": {
                 "type": "zip",
                 "url": "https://github.com/jakobw/libphutil/archive/master.zip",


### PR DESCRIPTION
In order to use Phabricator API conduit token instead of conduit certificate, "hacked" libphutil should be updated.
As the custom version of the library has no "real" releases, composer does not notice when it changes.
This is probably not the most elegant way to solve the problem but bumping the version number makes composer to update the library if it has been already installed.
Actually, this might be the only way to update that kind of "package", according to note in https://getcomposer.org/doc/05-repositories.md#package-2

As also mentioned in the Composer documentation, I am removing the `source` definition as it has no use for this dependency.