### PR TITLE
Drop not needed before script in TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
 
 sudo: false
 
-before_script: composer install --prefer-source
-
 install: travis_retry composer install --prefer-source
 
 script: composer ci


### PR DESCRIPTION
Same command being run in the `install` step as well. I believe once is enough.