### PR TITLE
test independence

### DIFF
--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -177,8 +177,6 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	 */
 	public function aSprintExistsForTheProject($sprintTitle, $projectTitle)
 	{
-		Auth::login(User::where('username', $this->params['phabricator_username'])->first()); // this is a bit ugly.
-
 		$project = Project::firstOrCreate(['title' => $projectTitle]);
 		$phabricatorProject = $this->getOrCreatePhabricatorProjectFromTitle($sprintTitle);
 		$existingSprint = Sprint::where('phid', $phabricatorProject['phid'])->first();

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -346,6 +346,15 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	}
 
 	/**
+	 * @Given I copied the :sprint Phabricator ID from Phabricator
+	 */
+	public function iCopiedThePhabricatorIdFromPhabricator($sprint)
+	{
+		$phabricatorProject = $this->getOrCreatePhabricatorProjectFromTitle($sprint);
+		$this->phabricatorProjectID = $phabricatorProject['id'];
+	}
+
+	/**
 	 * @Given I copied the :project :sprint Phabricator ID
 	 */
 	public function iCopiedThePhabricatorId($project, $sprint)

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -332,6 +332,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	 */
 	public function aSprintExistsForTheProjectInPhabricatorButNotInPhragile($sprintTitle, $projectTitle)
 	{
+		$this->getOrCreatePhabricatorProjectFromTitle($sprintTitle);
 		$project = Project::where('title', $projectTitle)->first();
 		try
 		{

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -353,18 +353,6 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	}
 
 	/**
-	 * @Given I copied the :project :sprint Phabricator ID
-	 */
-	public function iCopiedThePhabricatorId($project, $sprint)
-	{
-		$this->phabricatorProjectID = Sprint::where(
-			'title', $sprint
-		)->where(
-			'project_id', Project::where('title', $project)->first()->id
-		)->first()->phabricator_id;
-	}
-
-	/**
 	 * @When I paste the copied Phabricator ID
 	 */
 	public function iPasteTheCopiedPhabricatorId()

--- a/tests/acceptance/connect_existing_project.feature
+++ b/tests/acceptance/connect_existing_project.feature
@@ -5,6 +5,8 @@ Feature: Connect Existing Sprint Project
 
   Background:
     Given I am logged in
+    And I submit a valid Conduit API Token
+    And the "Wikidata" project exists
     And I am on the "Wikidata" project page
 
   Scenario: Connect existing project
@@ -26,8 +28,8 @@ Feature: Connect Existing Sprint Project
     Then I should see "The title has already been taken"
 
   Scenario: Connect using a Phabricator ID
-    Given I copied the "Wikidata" "Test Sprint" Phabricator ID
-    And a sprint "Test Sprint" exists for the "Wikidata" project in Phabricator but not in Phragile
+    Given a sprint "Test Sprint" exists for the "Wikidata" project in Phabricator but not in Phragile
+    And I copied the "Test Sprint" Phabricator ID from Phabricator
     When I click "New sprint"
     And I paste the copied Phabricator ID
     And I fill in "sprint_start" with "2015-04-01"

--- a/tests/acceptance/create_sprint.feature
+++ b/tests/acceptance/create_sprint.feature
@@ -5,6 +5,8 @@ Feature: Create Sprint
 
   Background:
     Given I am logged in
+    And I submit a valid Conduit API Token
+    And the "Wikidata" project exists
     And I am on the "Wikidata" project page
 
   Scenario: Create new sprint

--- a/tests/acceptance/json_export.feature
+++ b/tests/acceptance/json_export.feature
@@ -4,7 +4,9 @@ Feature: Export Chart Data
   I want to be able to access the charts' underlying data.
 
   Background:
-    Given a sprint "Sprint 42" exists for the "Wikidata" project
+    Given I am logged in
+    And I submit a valid Conduit API Token
+    And a sprint "Sprint 42" exists for the "Wikidata" project
     And the sprint "Sprint 42" starts on "2014-11-25" and ends on "2014-12-08"
 
   Scenario: View exported sprint

--- a/tests/acceptance/sprint_overview.feature
+++ b/tests/acceptance/sprint_overview.feature
@@ -20,9 +20,10 @@ Feature: Sprint Overview
     And I should see "8"
 
   Scenario: Assignees in Sprint Backlog
-    Given "Wikidata Sprint 42" contains a task
+    Given I am logged in
+    And "Sprint 42" contains a task
     When I am assigned to this task
-    And I go to the "Wikidata Sprint 42" sprint overview
+    And I go to the "Sprint 42" sprint overview
     Then I should see my name in the task's row of the sprint backlog
 
   Scenario: Sprint duration

--- a/tests/acceptance/unknown_sprint.feature
+++ b/tests/acceptance/unknown_sprint.feature
@@ -5,6 +5,7 @@ Feature: Unknown Sprint Page
 
   Scenario: Sprint exists in Phabricator but not in Phragile
     Given I am logged in
+    And the "Wikidata" project exists
     And a sprint "Test Sprint" exists for the "Wikidata" project in Phabricator but not in Phragile
     When I go to the sprint overview of the missing sprint
     And I select "Wikidata" from "project"
@@ -15,6 +16,7 @@ Feature: Unknown Sprint Page
 
   Scenario: Not logged in
     Given I am not logged in
+    And the "Wikidata" project exists
     And a sprint "Test Sprint" exists for the "Wikidata" project in Phabricator but not in Phragile
     When I go to the sprint overview of the missing sprint
     Then I should see "Please log in to connect the sprint with Phragile."


### PR DESCRIPTION
Includes https://github.com/wmde/phragile/pull/182 what should be merged first.

By adding 

	/** @BeforeScenario */
	public function before($event)
	{
		exec('php artisan migrate:refresh');
	}

to your `FeatureContext.php` the Phragile DB should be reset before each _scenario_.  Running this test with this setting show, that each test could run independent of the others on a fresh Phragile installation. - Of cause the Phabricator DB is not cleaned what leaves a small amount of uncertainty. But at least it is a first step.  

