### PR TITLE
Fix failing tests for first authorization.

### DIFF
--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -62,6 +62,10 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		$this->fillField('username', $this->params['phabricator_username']);
 		$this->fillField('password', $this->params['phabricator_password']);
 		$this->pressButton('Login');
+		if ($this->assertSession()->elementExists('css', 'button:contains("Authorize Access")'))
+		{
+			$this->pressButton('Authorize Access');
+		}
 		$this->clickLink('Continue');
 	}
 


### PR DESCRIPTION
All behat tests requiring login currently fail if the user has never authorized Phragile OAuth before. This can be tested by revoking Phragile on `[PHABRICATOR]/settings/panel/oauthorizations/`

This should patch fix it!