### PR TITLE
Fix stats

### DIFF
--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -5,15 +5,8 @@ class StatsController extends Controller {
 	public function index()
 	{
 		return View::make('stats.index')->with([
-			'projectCount' => Project::count(),
 			'sprintCount' => Sprint::count(),
-			'sprintsPerProject' => $this->getSprintsPerProject(),
+			'projects' => Project::with('sprints'),
 		]);
-	}
-
-	private function getSprintsPerProject() {
-		return Project::all()->map(function($project) {
-			return [$project->title, $project->sprints->count()];
-		});
 	}
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -132,5 +132,6 @@ Route::post('sprints/connect', [
 
 Route::get('/stats', [
 	'as' => 'stats',
+	'middleware' => 'admin',
 	'uses' => 'StatsController@index'
 ]);

--- a/resources/views/stats/index.blade.php
+++ b/resources/views/stats/index.blade.php
@@ -9,55 +9,49 @@
     <div class="container">
         <h1>Project statistics</h1>
 
-        @if(Auth::check() && Auth::user()->isInAdminList(env('PHRAGILE_ADMINS')))
-            <p>Overall numbers</p>
-            <table class="table table-striped">
-                <thead>
-                <tr>
-                    <th width="50%">Name</th>
-                    <th>Value</th>
-                </tr>
-                </thead>
-                <tbody class="list">
-                <tr>
-                    <td>Projects</td>
-                    <td>{!! $projects->count() !!}</td>
-                </tr>
-                <tr>
-                    <td>Sprints</td>
-                    <td>{!! $sprintCount !!}</td>
-                </tr>
-                </tbody>
-            </table>
+        <p>Overall numbers</p>
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th width="50%">Name</th>
+                <th>Value</th>
+            </tr>
+            </thead>
+            <tbody class="list">
+            <tr>
+                <td>Projects</td>
+                <td>{!! $projects->count() !!}</td>
+            </tr>
+            <tr>
+                <td>Sprints</td>
+                <td>{!! $sprintCount !!}</td>
+            </tr>
+            </tbody>
+        </table>
 
-            <p>Sprints per project</p>
-            <table class="table table-striped">
-                <thead>
+        <p>Sprints per project</p>
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th width="50%">Title</th>
+                <th>Count</th>
+            </tr>
+            </thead>
+            <tbody class="list">
+            @foreach($projects->get() as $project)
                 <tr>
-                    <th width="50%">Title</th>
-                    <th>Count</th>
+                    <td>
+                        {!! link_to_route(
+                            'project_path',
+                            $project->title,
+                            ['project' => $project->slug]
+                        ) !!}
+                    </td>
+                    <td>{{ $project->sprints->count() }}</td>
                 </tr>
-                </thead>
-                <tbody class="list">
-                @foreach($projects->get() as $project)
-                    <tr>
-                        <td>
-                            {!! link_to_route(
-                                'project_path',
-                                $project->title,
-                                ['project' => $project->slug]
-                            ) !!}
-                        </td>
-                        <td>{{ $project->sprints->count() }}</td>
-                    </tr>
-                @endforeach
-                </tbody>
-            </table>
-        @else
-            <p>
-                Log in using your Phabricator account to see usage statistics.
-            </p>
-        @endif
+            @endforeach
+            </tbody>
+        </table>
     </div>
     <div class="clearfix"></div>
 </div>

--- a/resources/views/stats/index.blade.php
+++ b/resources/views/stats/index.blade.php
@@ -21,7 +21,7 @@
                 <tbody class="list">
                 <tr>
                     <td>Projects</td>
-                    <td>{!! $projectCount !!}</td>
+                    <td>{!! $projects->count() !!}</td>
                 </tr>
                 <tr>
                     <td>Sprints</td>
@@ -39,16 +39,16 @@
                 </tr>
                 </thead>
                 <tbody class="list">
-                @foreach($sprintsPerProject as $projectSprints)
+                @foreach($projects->get() as $project)
                     <tr>
                         <td>
                             {!! link_to_route(
                                 'project_path',
-                                $projectSprints[0],
-                                ['project' => $projectSprints[0]]
+                                $project->title,
+                                ['project' => $project->slug]
                             ) !!}
                         </td>
-                        <td>{{ $projectSprints[1] }}</td>
+                        <td>{{ $project->sprints->count() }}</td>
                     </tr>
                 @endforeach
                 </tbody>


### PR DESCRIPTION
Links to projects were broken on the stats page as they used the title in the URL instead of the slug.
I also decided to check on the middleware level whether the user is an admin to make things a little bit cleaner.