### PR TITLE
Switch to use libphutil fork from the wmde namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
 			"package": {
 				"name": "libphutil",
 				"dist": {
-					"url": "https://github.com/jakobw/libphutil/archive/master.zip",
+					"url": "https://github.com/wmde/libphutil/archive/master.zip",
 					"type": "zip"
 				},
-				"version": "1.1"
+				"version": "1.2"
 			}
 		}
 	],
@@ -25,7 +25,7 @@
 		"laracasts/flash": "~1.0",
 		"guzzlehttp/guzzle": "~4.2",
 		"doctrine/dbal": "~2.4",
-		"libphutil": "1.1"
+		"libphutil": "1.2"
 	},
 	"require-dev": {
 		"behat/behat": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cc1d19da72c2acf0f4d1aafb8da28dd2",
-    "content-hash": "9d05867214070cd9dbe34e3a7c21f82b",
+    "hash": "b4d768bbe89b710f8abfed6760d5e463",
+    "content-hash": "1421089d8674f02591a355049b6f8f10",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -1231,10 +1231,10 @@
         },
         {
             "name": "libphutil",
-            "version": "1.1",
+            "version": "1.2",
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/jakobw/libphutil/archive/master.zip",
+                "url": "https://github.com/wmde/libphutil/archive/master.zip",
                 "reference": null,
                 "shasum": null
             },


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T124037

This is switching to use WMDE's fork: https://github.com/wmde/libphutil.
It uses the same Jakob's commit as https://github.com/jakobw/libphutil did.
Only difference is that WMDE is "more up-to-date" with the upstream (two more commits that they added a week ago). This should not affect Phragile but I think it is worth to have this checked by someone else than only me before we really switch the repo.

Version bump in `composer.*` is needed to have wmde version installed.