### PR TITLE
Show an error when the project cannot be found.

### DIFF
--- a/app/Http/Controllers/ProjectsController.php
+++ b/app/Http/Controllers/ProjectsController.php
@@ -4,10 +4,20 @@ class ProjectsController extends Controller {
 
 	public function show(Project $project)
 	{
+		if (!$project->exists)
+		{
+			return $this->projectNotFound();
+		}
+
 		$currentSprint = $project->currentSprint();
 
 		return $currentSprint ? App::make('SprintsController')->show($currentSprint)
 		                      : View::make('project.view', compact('project'));
+	}
+
+	private function projectNotFound()
+	{
+		return View::make('project.not_found', ['projects' => Project::all()]);
 	}
 
 	public function index()

--- a/resources/views/project/index.blade.php
+++ b/resources/views/project/index.blade.php
@@ -19,23 +19,7 @@
 			</p>
 
 			<p>
-				<div class="dropdown">
-					<button class="btn btn-lg btn-primary" data-toggle="dropdown">
-						Select a Project
-						<span class="caret"></span>
-					</button>
-					<ul class="dropdown-menu" id="projects">
-						@foreach($projects as $project)
-							<li>
-								{!! link_to_route(
-									'project_path',
-									$project->title,
-									['project' => $project->slug]
-								) !!}
-							</li>
-						@endforeach
-					</ul>
-				</div>
+				@include('project.partials.select')
 
 				@if(Auth::check() && Auth::user()->isInAdminList(env('PHRAGILE_ADMINS')))
 					@include('project.partials.create')

--- a/resources/views/project/not_found.blade.php
+++ b/resources/views/project/not_found.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.default')
+
+@section('title', "Phragile - Project not found")
+
+@section('content')
+    <h1>Project not found</h1>
+    <p>
+        It looks like this project does not exist.
+    </p>
+    <p>
+        @include('project.partials.select')
+    </p>
+@stop

--- a/resources/views/project/partials/select.blade.php
+++ b/resources/views/project/partials/select.blade.php
@@ -1,0 +1,17 @@
+<div class="dropdown">
+    <button class="btn btn-lg btn-primary" data-toggle="dropdown">
+        Select a Project
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" id="projects">
+        @foreach($projects as $project)
+            <li>
+                {!! link_to_route(
+                    'project_path',
+                    $project->title,
+                    ['project' => $project->slug]
+                ) !!}
+            </li>
+        @endforeach
+    </ul>
+</div>

--- a/tests/acceptance/projects.feature
+++ b/tests/acceptance/projects.feature
@@ -32,3 +32,9 @@ Feature: Projects
     When I fill in "title" with "Foobar"
     And I press "Create"
     Then I should see "A project with this title already exists."
+
+  Scenario: Error for projects that do not exist
+    Given the project "Foobar" does not exist
+    When I go to "/projects/foobar"
+    Then I should see "It looks like this project does not exist."
+    And I should see "Select a project"


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T124034
Going to `/projects/not-a-project` now shows an error and lets the user select a different project from a dropdown with all projects.
While implementing I was questioning whether a dedicated page for this is needed or if we should just redirect to `/` with (or even without) a flash message. Thoughts?