### PR TITLE
Only use colons in labels of "inline form fields"

### DIFF
--- a/resources/views/project/partials/create.blade.php
+++ b/resources/views/project/partials/create.blade.php
@@ -12,7 +12,7 @@
             {!! Form::open(['method' => 'POST', 'route' => 'create_project_path']) !!}
                 <div class="modal-body">
                     <div class="form-group">
-                        {!! Form::label('title', 'Title:') !!}
+                        {!! Form::label('title', 'Title') !!}
                         {!! Form::text('title', '', ['class' => 'form-control']) !!}
                     </div>
                 </div>

--- a/resources/views/sprint/connect.blade.php
+++ b/resources/views/sprint/connect.blade.php
@@ -20,7 +20,7 @@
         {!! Form::text('title', $phabricatorProject['id'], ['class' => 'hidden']) !!}
 
         <div class="form-group">
-            {!! Form::label('project', 'Project:') !!}
+            {!! Form::label('project', 'Project') !!}
             {!! Form::select('project', $projects, null, ['class' => 'form-control']) !!}
         </div>
 
@@ -29,12 +29,12 @@
             {!! Form::text('sprint_end', $duration['end'], ['class' => 'hidden']) !!}
         @else
             <div class="form-group">
-                {!! Form::label('sprint_start', 'Sprint start:') !!}
+                {!! Form::label('sprint_start', 'Sprint start') !!}
                 {!! Form::text('sprint_start', '', ['class' => 'form-control datepicker start']) !!}
             </div>
 
             <div class="form-group">
-                {!! Form::label('sprint_end', 'Sprint end:') !!}
+                {!! Form::label('sprint_end', 'Sprint end') !!}
                 {!! Form::text('sprint_end', '', ['class' => 'form-control datepicker end']) !!}
             </div>
         @endif

--- a/resources/views/sprint/partials/settings_form.blade.php
+++ b/resources/views/sprint/partials/settings_form.blade.php
@@ -8,22 +8,22 @@
             {!! Form::model($sprint, ['route' => ['sprint_settings_path', $sprint->phabricator_id], 'method' => 'PUT']) !!}
             <div class="modal-body">
                 <div class="form-group">
-                    {!! Form::label('sprint_start', 'Sprint start:') !!}
+                    {!! Form::label('sprint_start', 'Sprint start') !!}
                     {!! Form::text('sprint_start', $sprint->sprint_start, ['class' => 'form-control datepicker start']) !!}
                 </div>
 
                 <div class="form-group">
-                    {!! Form::label('sprint_end', 'Sprint end:') !!}
+                    {!! Form::label('sprint_end', 'Sprint end') !!}
                     {!! Form::text('sprint_end', $sprint->sprint_end, ['class' => 'form-control datepicker end']) !!}
                 </div>
 
                 <div class="form-group">
-                    {!! Form::label('title', 'Title:') !!}
+                    {!! Form::label('title', 'Title') !!}
                     {!! Form::text('title', $sprint->title, ['class' => 'form-control', 'id' => 'sprint-title']) !!}
                 </div>
 
                 <div class="form-group">
-                    {!! Form::label('project_id', 'Project:') !!}
+                    {!! Form::label('project_id', 'Project') !!}
                     {!! Form::select('project_id', $projects, $sprint->project_id, ['class' => 'form-control']) !!}
                 </div>
 


### PR DESCRIPTION
As has been suggested in https://github.com/wmde/phragile/pull/185#issuecomment-176126309 it is not necessary to use colons at the end of form field label if the field is situated below the label.
I other words: colons would be now only in the Project Settings form, where labels are "inline" (fields are next to their labels, not below).