### PR TITLE
Allow failures of HHVM TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 matrix:
   allow_failures:
     - php: 7
+    - php: hhvm
 
 addons:
   hosts:


### PR DESCRIPTION
This is not something "obligatory" to merge. Just opening it in case Travis HHVM build gets really unstable. Currently HHVM build seems to sometimes fail at random points (in particular: some behat tests fail).
When HHVM build continously fail, this could be merged (and probably pending PRs with failing CI builds rebased) so the build wouldn't need to re-run multiple times until it passes.
If the situation with HHVM build looks good, this could be simply closed and forgotten.