### PR TITLE
Add tests to verify that most recent column change is considered when generating burndown chart

### DIFF
--- a/tests/unit/BurndownChartTest.php
+++ b/tests/unit/BurndownChartTest.php
@@ -188,6 +188,56 @@ class BurndownChartTest extends TestCase {
 		$this->assertSame(10, $burndown->getPointsClosedPerDay()['2014-12-08']);
 	}
 
+	public function testClosedPerDayConsidersMostRecentColumnChangeInWorkboardMode()
+	{
+		$burndown = $this->mockWithTransactionsInWorkboardMode(
+			$this->tasks,
+			[
+				'1' => [
+					[
+						'transactionType' => 'projectcolumn',
+						'oldValue' => [
+							'columnPHIDs' => ['anyNotClosed'],
+							'projectPHID' => $this->testProjectPHID,
+						],
+						'newValue' => [
+							'columnPHIDs' => [$this->closedColumnPHIDs[1]],
+							'projectPHID' => $this->testProjectPHID,
+						],
+						'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 10:00:00')->format('U'),
+					],
+					[
+						'transactionType' => 'projectcolumn',
+						'oldValue' => [
+							'columnPHIDs' => [$this->closedColumnPHIDs[1]],
+							'projectPHID' => $this->testProjectPHID,
+						],
+						'newValue' => [
+							'columnPHIDs' => ['anyNotClosed'],
+							'projectPHID' => $this->testProjectPHID,
+						],
+						'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 12:00:00')->format('U'),
+					],
+					[
+						'transactionType' => 'projectcolumn',
+						'oldValue' => [
+							'columnPHIDs' => ['anyNotClosed'],
+							'projectPHID' => $this->testProjectPHID,
+						],
+						'newValue' => [
+							'columnPHIDs' => [$this->closedColumnPHIDs[1]],
+							'projectPHID' => $this->testProjectPHID,
+						],
+						'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '09.12.2014 10:00:00')->format('U'),
+					],
+				],
+			]
+		);
+
+		$this->assertSame(0, $burndown->getPointsClosedPerDay()['2014-12-08']);
+		$this->assertSame(8, $burndown->getPointsClosedPerDay()['2014-12-09']);
+	}
+
 	public function testClosedPerDayAddsStoryPointsInWorkboardMode()
 	{
 		$burndown = $this->mockWithTransactionsInWorkboardMode(

--- a/tests/unit/StatusByWorkboardDispatcherTest.php
+++ b/tests/unit/StatusByWorkboardDispatcherTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use Phragile\PhabricatorAPI;
+use Phragile\ProjectColumnRepository;
+use Phragile\StatusByWorkboardDispatcher;
+use Phragile\TransactionList;
+
+/**
+ * @covers Phragile\StatusByWorkboardDispatcher
+ */
+class StatusByWorkboardDispatcherTest extends TestCase {
+
+	private $workboardColumns = [
+		'PHID-123abc' => 'backlog',
+		'PHID-321cba' => 'done',
+		'PHID-abc123' => 'to do',
+	];
+
+	private function newPhabricatorAPI()
+	{
+		$phabricatorAPI = $this->getMockBuilder( PhabricatorAPI::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$phabricatorAPI->method('queryPHIDs')->will($this->returnCallback(function()
+		{
+			return array_map(function($column)
+			{
+				return ['name' => $column];
+			}, $this->workboardColumns);
+		}));
+		return $phabricatorAPI;
+	}
+
+	private function newSprint()
+	{
+		$sprint = new Sprint([
+			'phid' => 'PHID-123',
+		]);
+		$sprint->project = new Project([
+			'closed_statuses' => 'done',
+			'default_column' => 'backlog',
+		]);
+		return $sprint;
+	}
+
+	private function newDispatcher(Sprint $sprint, array $transactions)
+	{
+		return new StatusByWorkboardDispatcher(
+			$sprint,
+			new TransactionList($transactions),
+			new ProjectColumnRepository(
+				'PHID-123',
+				$transactions,
+				$this->newPhabricatorAPI()
+			)
+		);
+	}
+
+	public function testGivenNoTransactionForTask_tasksStatusIsBasedOnProjectsDefaultColumn()
+	{
+		$sprint = $this->newSprint();
+		$task = ['id' => 'fooTask'];
+		$transactions = [];
+		$dispatcher = $this->newDispatcher($sprint, $transactions);
+		$this->assertEquals('backlog', $dispatcher->getStatus($task));
+		$this->assertFalse($dispatcher->isClosed($task));
+	}
+
+	public function testGivenSingleTransactionForTask_tasksStatusIsBasedOnThatTransaction()
+	{
+		$sprint = $this->newSprint();
+		$task = ['id' => 'fooTask'];
+		$transactions = [];
+		$transactions['fooTask'][] = $this->getFirstTransaction();
+		$dispatcher = $this->newDispatcher($sprint, $transactions);
+		$this->assertEquals('done', $dispatcher->getStatus($task));
+		$this->assertTrue($dispatcher->isClosed($task));
+	}
+
+	public function testGivenTwoTransactionsForTask_tasksStatusIsBasedOnTheMostRecentTransaction()
+	{
+		$sprint = $this->newSprint();
+		$task = ['id' => 'fooTask'];
+		$transactions = [];
+		$transactions['fooTask'][] = $this->getFirstTransaction();
+		$transactions['fooTask'][] = $this->getSecondTransaction();
+		$dispatcher = $this->newDispatcher($sprint, $transactions);
+		$this->assertEquals('to do', $dispatcher->getStatus($task));
+		$this->assertFalse($dispatcher->isClosed($task));
+	}
+
+	public function testGivenThreeTransactionsForTask_tasksStatusIsBasedOnTheMostRecentTransaction()
+	{
+		$sprint = $this->newSprint();
+		$task = ['id' => 'fooTask'];
+		$transactions = [];
+		$transactions['fooTask'][] = $this->getFirstTransaction();
+		$transactions['fooTask'][] = $this->getSecondTransaction();
+		$transactions['fooTask'][] = $this->getThirdTransaction();
+		$dispatcher = $this->newDispatcher($sprint, $transactions);
+		$this->assertEquals('done', $dispatcher->getStatus($task));
+		$this->assertTrue($dispatcher->isClosed($task));
+	}
+
+	private function getFirstTransaction()
+	{
+		return [
+			'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
+			'transactionType' => 'projectcolumn',
+			'oldValue' => [
+				'columnPHIDs' => [$this->getColumnPhid('to do')],
+				'projectPHID' => 'PHID-123',
+			],
+			'newValue' => [
+				'columnPHIDs' => [$this->getColumnPhid('done')],
+				'projectPHID' => 'PHID-123',
+			]
+		];
+	}
+
+	private function getSecondTransaction()
+	{
+		return [
+			'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 12:00:00')->format('U'),
+			'transactionType' => 'projectcolumn',
+			'oldValue' => [
+				'columnPHIDs' => [$this->getColumnPhid('done')],
+				'projectPHID' => 'PHID-123',
+			],
+			'newValue' => [
+				'columnPHIDs' => [$this->getColumnPhid('to do')],
+				'projectPHID' => 'PHID-123',
+			]
+		];
+	}
+
+	private function getThirdTransaction()
+	{
+		return [
+			'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 13:00:00')->format('U'),
+			'transactionType' => 'projectcolumn',
+			'oldValue' => [
+				'columnPHIDs' => [$this->getColumnPhid('to do')],
+				'projectPHID' => 'PHID-123',
+			],
+			'newValue' => [
+				'columnPHIDs' => [$this->getColumnPhid('done')],
+				'projectPHID' => 'PHID-123',
+			]
+		];
+	}
+
+	private function getColumnPhid($name)
+	{
+		$columnPHIDs = array_flip($this->workboardColumns);
+		return $columnPHIDs[$name];
+	}
+
+}

--- a/tests/unit/TransactionListTest.php
+++ b/tests/unit/TransactionListTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Phragile\TransactionList;
+
+/**
+ * @covers Phragile\TransactionList
+ */
+class TransactionListTest extends PHPUnit_Framework_TestCase {
+
+	public function testTaskTransactionsAreSortedByTimestamp()
+	{
+		$transactions = [
+			'fooTask' => [
+				[
+					'dateCreated' => DateTime::createFromFormat('d.m.Y', '02.01.2016')->format('U'),
+					'transactionType' => 'projectcolumn',
+					'oldValue' => [
+						'columnPHIDs' => ['PHID-doing'],
+						'projectPHID' => 'PHID-PROJ-AWESOME',
+					],
+					'newValue' => [
+						'columnPHIDs' => ['PHID-done'],
+						'projectPHID' => 'PHID-PROJ-AWESOME',
+					]
+				],
+				[
+					'dateCreated' => DateTime::createFromFormat('d.m.Y', '01.01.2016')->format('U'),
+					'transactionType' => 'projectcolumn',
+					'oldValue' => [
+						'columnPHIDs' => ['PHID-backlog'],
+						'projectPHID' => 'PHID-PROJ-AWESOME',
+					],
+					'newValue' => [
+						'columnPHIDs' => ['PHID-doing'],
+						'projectPHID' => 'PHID-PROJ-AWESOME',
+					]
+				],
+				[
+					'dateCreated' => DateTime::createFromFormat('d.m.Y', '03.01.2016')->format('U'),
+					'transactionType' => 'projectcolumn',
+					'oldValue' => [
+						'columnPHIDs' => ['PHID-doing'],
+						'projectPHID' => 'PHID-PROJ-AWESOME',
+					],
+					'newValue' => [
+						'columnPHIDs' => ['PHID-done'],
+						'projectPHID' => 'PHID-PROJ-AWESOME',
+					]
+				],
+			]
+		];
+		$sortedTransactions = (new TransactionList($transactions))->getChronologicallySorted();
+		$this->assertEquals(
+			'01.01.2016',
+			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][0]['dateCreated'])->format('d.m.Y')
+		);
+		$this->assertEquals(
+			'02.01.2016',
+			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][1]['dateCreated'])->format('d.m.Y')
+		);
+		$this->assertEquals(
+			'03.01.2016',
+			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][2]['dateCreated'])->format('d.m.Y')
+		);
+	}
+
+}


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T103071

As I understand the problem described in Phabricator ticket, at some point Phragile considered tasked being closed at the point it first got moved to the "closed" column, even if it has been moved back to "not closed" column afterwards.
If I am not mistaken this behaviour has been (possibly unintentionally) fixed along some other changes at some point (didn't manage to find the actual change).
`BurndownChartTest::testClosedPerDayConsidersMostRecentColumnChangeInWorkboardMode` is about checking the behaviour I described above. Also adding tests for two other classes involved that prove that the most recent column-change transaction is considered.

If I am wrong in what the Phab task is about, please comment!