### PR TITLE
Fix closed statuses column name in TaskListTest

### DIFF
--- a/tests/unit/TaskListTest.php
+++ b/tests/unit/TaskListTest.php
@@ -60,7 +60,7 @@ class TaskListTest extends TestCase {
 			'phid' => 'PHID-123',
 		]);
 		$this->testSprint->project = new Project([
-			'closed_columns' => 'done',
+			'closed_statuses' => 'done',
 		]);
 	}
 


### PR DESCRIPTION
Apparently the name does not affect tests but fixing the name as it might be misleading (I got tricked while writing https://github.com/wmde/phragile/commit/d04dfa7bba27c1161d7321f12ec95aa0217baa8b) and it is generally wrong.