### PR TITLE
Discontinue certificate

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -36,6 +36,11 @@ class Handler extends ExceptionHandler {
 	 */
 	public function render($request, Exception $e)
 	{
+		if ($e instanceof \ConduitClientException && $e->getErrorCode() === 'ERR-INVALID-SESSION')
+		{
+			return response()->view('errors.missing_api_token', [], 500);
+		}
+
 		if ($this->isHttpException($e))
 		{
 			return $this->renderHttpException($e);

--- a/app/Http/Controllers/SprintsController.php
+++ b/app/Http/Controllers/SprintsController.php
@@ -50,7 +50,7 @@ class SprintsController extends Controller {
 		$user = Auth::user();
 		$user->setPhabricatorURL(env('PHABRICATOR_URL'));
 
-		if (!$user->apiTokenValid() && !$user->certificateValid())
+		if (!$user->apiTokenValid())
 		{
 			Flash::warning('Please set a valid Conduit API Token before trying to create a new sprint.');
 			return Redirect::back();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,6 +1,5 @@
 <?php
 
-use Phragile\PhabricatorAPI;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 
@@ -24,20 +23,6 @@ class User extends Eloquent implements AuthenticatableContract {
 	public function setPhabricatorURL($url)
 	{
 		$this->phabricatorURL = $url;
-	}
-
-	public function certificateValid($certificate = null)
-	{
-		try
-		{
-			$phabricator = new PhabricatorAPI(new ConduitClient($this->phabricatorURL));
-			$phabricator->connect($this->username, $certificate ?: $this->conduit_certificate);
-		} catch (ConduitClientException $e)
-		{
-			return false;
-		}
-
-		return true;
 	}
 
 	public function apiTokenValid($token = null)

--- a/app/Phragile/ActionHandler/SprintStoreActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintStoreActionHandler.php
@@ -23,6 +23,7 @@ class SprintStoreActionHandler {
 	{
 		$this->sprint = $sprint;
 		$this->user = $user;
+		$this->user->setPhabricatorURL(env('PHABRICATOR_URL'));
 
 		$this->validate();
 		$this->trySprintCreationFromPhabricatorID();
@@ -76,16 +77,12 @@ class SprintStoreActionHandler {
 	{
 		if ($this->previousActionFailed()) return;
 
-		if(!empty($this->user->conduit_api_token)) {
+		if ($this->user->apiTokenValid())
+		{
 			$this->userPhabricatorAPI->setConduitAPIToken($this->user->conduit_api_token);
-		} else {
-			try
-			{
-				$this->userPhabricatorAPI->connect($this->user->username, $this->user->conduit_certificate);
-			} catch(\ConduitClientException $e)
-			{
-				$this->redirectBackWithError($e->getMessage());
-			}
+		} else
+		{
+			$this->redirectBackWithError('Please make sure you are using a valid Conduit API token.');
 		}
 	}
 

--- a/app/Phragile/PhabricatorAPI.php
+++ b/app/Phragile/PhabricatorAPI.php
@@ -16,19 +16,6 @@ class PhabricatorAPI {
 		$this->client->setConduitToken($token);
 	}
 
-	public function connect($user, $certificate)
-	{
-		return $this->client->callMethodSynchronous(
-			'conduit.connect',
-			[
-				'client' => 'Phragile',
-				'clientVersion' => 1,
-				'user' => $user,
-				'certificate' => $certificate
-			]
-		);
-	}
-
 	public function createProject($title, array $members = [])
 	{
 		$response = $this->client->callMethodSynchronous(

--- a/app/Phragile/Providers/PhabricatorAPIServiceProvider.php
+++ b/app/Phragile/Providers/PhabricatorAPIServiceProvider.php
@@ -7,16 +7,11 @@ use Phragile\PhabricatorAPI;
 class PhabricatorAPIServiceProvider extends ServiceProvider {
 	public function register()
 	{
-		$this->app->singleton('phabricator', function() {
-			if(env('PHRAGILE_BOT_API_TOKEN')) {
-				$client = new \ConduitClient(env('PHABRICATOR_URL'));
-				$client->setConduitToken(env('PHRAGILE_BOT_API_TOKEN'));
-				$phabricator = new PhabricatorAPI($client);
-			} else {
-				$phabricator = new PhabricatorAPI(new \ConduitClient(env('PHABRICATOR_URL')));
-				$phabricator->connect(env('PHRAGILE_BOT_NAME'), env('PHRAGILE_BOT_CERTIFICATE')); // still allow deprecated auth with certificate
-			}
-			return $phabricator;
+		$this->app->singleton('phabricator', function()
+		{
+			$client = new \ConduitClient(env('PHABRICATOR_URL'));
+			$client->setConduitToken(env('PHRAGILE_BOT_API_TOKEN'));
+			return new PhabricatorAPI($client);
 		});
 	}
 }

--- a/resources/views/errors/missing_api_token.blade.php
+++ b/resources/views/errors/missing_api_token.blade.php
@@ -1,0 +1,11 @@
+@extends('layouts.default')
+
+@section('title', 'Missing Conduit API Token')
+
+@section('content')
+    <h1>Missing Conduit API Token</h1>
+    <p>
+        You seem to be missing the Conduit API token for your Phragile bot.
+        <br>Make sure the <code>PHRAGILE_BOT_API_TOKEN</code> setting is configured correctly in your <code>.env</code>-file.
+    </p>
+@stop


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T124032
* removed all Conduit certificate code
* globally catches a `ConduitException` with an error code of `ERR-INVALID-SESSION` and will tell the user that the Conduit API token is missing in the .env file.

I wanted to write a behat test for the Exception but couldn't think of a good way to dynamically override the `PHABRICATOR_API_TOKEN` environment variable in the test.