### PR TITLE
Fix color order in pie chart.

### DIFF
--- a/app/Phragile/PieChart.php
+++ b/app/Phragile/PieChart.php
@@ -36,7 +36,7 @@ class PieChart {
 	{
 		uasort($data, function($a, $b)
 		{
-			return $a < $b ? 1 : -1;
+			return $a['cssClass'] > $b['cssClass'] ? 1 : -1;
 		});
 
 		return $data;

--- a/tests/unit/PieChartTest.php
+++ b/tests/unit/PieChartTest.php
@@ -72,4 +72,23 @@ class PieChartTest extends TestCase {
 		$this->assertArrayHasKey('closed deployed', $colorMap);
 		$this->assertArrayHasKey('closed wontfix', $colorMap);
 	}
+
+	public function testOrdersByCssClass()
+	{
+		$chart = new PieChart(
+			[
+				'Done' => ['points' => 10],
+				'Doing' => ['points' => 11],
+				'Blocked By Others' => ['points' => 12],
+				'Deployed' => ['points' => 13]
+			],
+			new StatusCssClassService(true, ['Done', 'Deployed'])
+		);
+
+		$colorMap = array_values($chart->getData());
+		$this->assertSame($colorMap[0]['cssClass'], 'closed deployed');
+		$this->assertSame($colorMap[1]['cssClass'], 'closed done');
+		$this->assertSame($colorMap[2]['cssClass'], 'open blocked-by-others');
+		$this->assertSame($colorMap[3]['cssClass'], 'open doing');
+	}
 }


### PR DESCRIPTION
I noticed that the colors of the pie chart are not in the correct order on http://phragile.wmflabs.org/projects/tcb .
It turned out that the logic was a bit foobar. Fixed and tested.