### PR TITLE
Maniphest search

### DIFF
--- a/app/Phragile/ActionHandler/SprintLiveDataActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintLiveDataActionHandler.php
@@ -4,6 +4,7 @@ namespace Phragile\ActionHandler;
 
 use Phragile\PhabricatorAPI;
 use Phragile\SettingsAwareTransactionFilter;
+use Phragile\TaskDataFetcher;
 use Phragile\TransactionLoader;
 use Sprint;
 use Phragile\Factory\SprintDataFactory;
@@ -38,7 +39,7 @@ class SprintLiveDataActionHandler {
 
 	private function getSprintDataFactory(Sprint $sprint)
 	{
-		$tasks = $this->phabricatorAPI->queryTasksByProject($sprint->phid);
+		$tasks = (new TaskDataFetcher($this->phabricatorAPI))->fetchProjectTasks($sprint->phid);
 		$taskIDs = array_map(function($task)
 		{
 			return $task['id'];

--- a/app/Phragile/BurndownChart.php
+++ b/app/Phragile/BurndownChart.php
@@ -35,10 +35,10 @@ class BurndownChart {
 
 			if (in_array($taskClosedDay, $sprintDuration))
 			{
-				$this->pointsClosedPerDay[$taskClosedDay] += $this->tasks->findTaskByID($id)['story_points'];
+				$this->pointsClosedPerDay[$taskClosedDay] += $this->tasks->findTaskByID($id)->getPoints();
 			} elseif ($taskClosedDay < $this->sprint->sprint_start)
 			{
-				$this->pointsClosedBeforeSprint += $this->tasks->findTaskByID($id)['story_points'];
+				$this->pointsClosedBeforeSprint += $this->tasks->findTaskByID($id)->getPoints();
 			}
 		}
 	}
@@ -101,7 +101,7 @@ class BurndownChart {
 		$closedTaskTransactions = [];
 		foreach ($transactions as $taskID => $taskTransactions)
 		{
-			if ($this->tasks->findTaskByID($taskID)['closed'])
+			if ($this->tasks->findTaskByID($taskID) && $this->tasks->findTaskByID($taskID)->isClosed())
 			{
 				$closedTaskTransactions[$taskID] = $taskTransactions;
 			}

--- a/app/Phragile/PhabricatorAPI.php
+++ b/app/Phragile/PhabricatorAPI.php
@@ -47,14 +47,19 @@ class PhabricatorAPI {
 		)['data']);
 	}
 
-	public function queryTasksByProject($projectPHID)
+	/**
+	 * Uses maniphest.search to search tasks for a project.
+	 * @param $projectPHID
+	 * @return array
+	 */
+	public function searchTasksByProjectPHID($projectPHID)
 	{
 		return $this->client->callMethodSynchronous(
-			'maniphest.query',
+			'maniphest.search',
 			[
-				'projectPHIDs' => [$projectPHID]
+				'constraints' => ['projects' => [$projectPHID]]
 			]
-		);
+		)['data'];
 	}
 
 	public function createTask($projectPHID, array $task)

--- a/app/Phragile/PhabricatorAPI.php
+++ b/app/Phragile/PhabricatorAPI.php
@@ -49,17 +49,20 @@ class PhabricatorAPI {
 
 	/**
 	 * Uses maniphest.search to search tasks for a project.
-	 * @param $projectPHID
+	 * @param string $projectPHID
+	 * @param string $after - Cursor parameter to fetch the next page of tasks
 	 * @return array
 	 */
-	public function searchTasksByProjectPHID($projectPHID)
+	public function searchTasksByProjectPHID($projectPHID, $after)
 	{
 		return $this->client->callMethodSynchronous(
 			'maniphest.search',
 			[
-				'constraints' => ['projects' => [$projectPHID]]
+				'constraints' => ['projects' => [$projectPHID]],
+				'attachments' => ['projects' => true],
+				'after' => $after
 			]
-		)['data'];
+		);
 	}
 
 	public function createTask($projectPHID, array $task)

--- a/app/Phragile/StatusByStatusFieldDispatcher.php
+++ b/app/Phragile/StatusByStatusFieldDispatcher.php
@@ -11,23 +11,23 @@ class StatusByStatusFieldDispatcher implements StatusDispatcher {
 
 	private function isTaskInReview(array $task)
 	{
-		return !$task['isClosed'] && in_array($this->reviewTagPHID, $task['projectPHIDs']);
+		return !$this->isClosed($task) && in_array($this->reviewTagPHID, $task['attachments']['projects']['projectPHIDs']);
 	}
 
 	private function isTaskBeingDone(array $task)
 	{
-		return !$task['isClosed'] && !is_null($task['ownerPHID']);
+		return !$this->isClosed($task) && !is_null($task['fields']['ownerPHID']);
 	}
 
 	public function getStatus(array $task)
 	{
 		if ($this->isTaskInReview($task)) return 'patch to review';
 		elseif ($this->isTaskBeingDone($task)) return 'doing';
-		else return $task['status'];
+		else return $task['fields']['status']['value'];
 	}
 
 	public function isClosed(array $task)
 	{
-		return $task['isClosed'];
+		return in_array($task['fields']['status']['value'], ['resolved', 'declined', 'invalid']);
 	}
 }

--- a/app/Phragile/Task.php
+++ b/app/Phragile/Task.php
@@ -1,0 +1,116 @@
+<?php
+namespace Phragile;
+
+class Task {
+	private $title;
+	private $priority;
+	private $points;
+	private $status;
+	private $closed;
+	private $id;
+	private $assigneePHID;
+	private $assigneeName;
+	private $cssClass;
+
+	function __construct($attributes)
+	{
+		$fields = ['title', 'priority', 'points', 'status', 'closed', 'id', 'assigneePHID'];
+		foreach ($fields as $field)
+		{
+			if (!key_exists($field, $attributes))
+			{
+				throw new \InvalidArgumentException("The $field field is missing.");
+			}
+
+			$this->$field = $attributes[$field];
+		}
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getTitle()
+	{
+		return $this->title;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getPriority()
+	{
+		return $this->priority;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getPoints()
+	{
+		return $this->points;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getStatus()
+	{
+		return $this->status;
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function isClosed()
+	{
+		return $this->closed;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId()
+	{
+		return $this->id;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getAssigneePHID()
+	{
+		return $this->assigneePHID;
+	}
+
+	/**
+	 * @param string $name
+	 */
+	public function setAssigneeName($name)
+	{
+		$this->assigneeName = $name;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getAssigneeName()
+	{
+		return $this->assigneeName;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCssClass()
+	{
+		return $this->cssClass;
+	}
+
+	/**
+	 * @param string $cssClass
+	 */
+	public function setCssClass($cssClass)
+	{
+		$this->cssClass = $cssClass;
+	}
+}

--- a/app/Phragile/Task.php
+++ b/app/Phragile/Task.php
@@ -12,12 +12,15 @@ class Task {
 	private $assigneeName;
 	private $cssClass;
 
-	function __construct($attributes)
+	/**
+	 * @param array $attributes - containing 'title', 'priority', 'points', 'status', 'closed', 'id', 'assigneePHID'
+	 */
+	function __construct(array $attributes)
 	{
 		$fields = ['title', 'priority', 'points', 'status', 'closed', 'id', 'assigneePHID'];
 		foreach ($fields as $field)
 		{
-			if (!key_exists($field, $attributes))
+			if (!array_key_exists($field, $attributes))
 			{
 				throw new \InvalidArgumentException("The $field field is missing.");
 			}

--- a/app/Phragile/TaskDataFetcher.php
+++ b/app/Phragile/TaskDataFetcher.php
@@ -15,7 +15,15 @@ class TaskDataFetcher {
 	 */
 	public function fetchProjectTasks($projectPHID)
 	{
-		// TODO: This is not yet working around the pagination/search limit.
-		return $this->phabricatorAPI->searchTasksByProjectPHID($projectPHID);
+		$rawTaskData = [];
+		$after = '0';
+		while (!is_null($after))
+		{
+			$response = $this->phabricatorAPI->searchTasksByProjectPHID($projectPHID, $after);
+			$after = $response['cursor']['after'];
+			$rawTaskData = array_merge($rawTaskData, $response['data']);
+		};
+
+		return $rawTaskData;
 	}
 }

--- a/app/Phragile/TaskDataFetcher.php
+++ b/app/Phragile/TaskDataFetcher.php
@@ -1,0 +1,21 @@
+<?php
+namespace Phragile;
+
+class TaskDataFetcher {
+	private $phabricatorAPI;
+
+	public function __construct(PhabricatorAPI $phabricatorAPI)
+	{
+		$this->phabricatorAPI = $phabricatorAPI;
+	}
+
+	/**
+	 * @param string $projectPHID
+	 * @return array
+	 */
+	public function fetchProjectTasks($projectPHID)
+	{
+		// TODO: This is not yet working around the pagination/search limit.
+		return $this->phabricatorAPI->searchTasksByProjectPHID($projectPHID);
+	}
+}

--- a/app/Phragile/TaskDataProcessor.php
+++ b/app/Phragile/TaskDataProcessor.php
@@ -1,0 +1,50 @@
+<?php
+namespace Phragile;
+
+class TaskDataProcessor {
+	private $statusDispatcher;
+	private $options;
+
+	public function __construct(StatusDispatcher $statusDispatcher, array $options)
+	{
+		$this->statusDispatcher = $statusDispatcher;
+		$this->options = $options;
+	}
+
+	/**
+	 * @param $rawData
+	 * @return Task[]
+	 */
+	public function process($rawData)
+	{
+		return array_filter(
+			array_map(function($task)
+			{
+				return new Task([
+					'title' => $task['fields']['name'],
+					'priority' => $task['fields']['priority']['name'],
+					'status' => $this->statusDispatcher->getStatus($task),
+					'points' => $this->options['ignore_estimates'] ? 1 : $this->getPoints($task),
+					'closed' => $this->statusDispatcher->isClosed($task),
+					'id' => $task['id'],
+					'assigneePHID' => $task['fields']['ownerPHID'],
+				]);
+			}, array_values($rawData)),
+			function(Task $task)
+			{
+				return !in_array($task->getStatus(), $this->options['ignored_columns']);
+			}
+		);
+	}
+
+	private function getPoints(array $task)
+	{
+		if (env('MANIPHEST_STORY_POINTS_FIELD') && isset($task['fields']['custom.' . env('MANIPHEST_STORY_POINTS_FIELD')]))
+		{
+			return $task['fields']['custom.' . env('MANIPHEST_STORY_POINTS_FIELD')];
+		} else
+		{
+			return $task['fields']['points'];
+		}
+	}
+}

--- a/app/Phragile/TaskDataProcessor.php
+++ b/app/Phragile/TaskDataProcessor.php
@@ -12,10 +12,10 @@ class TaskDataProcessor {
 	}
 
 	/**
-	 * @param $rawData
+	 * @param array $rawData
 	 * @return Task[]
 	 */
-	public function process($rawData)
+	public function process(array $rawData)
 	{
 		return array_filter(
 			array_map(function($task)

--- a/resources/views/sprint/view.blade.php
+++ b/resources/views/sprint/view.blade.php
@@ -133,11 +133,11 @@
 
 		<tbody class="list">
 			@foreach($sprintBacklog as $task)
-				<tr id="t{{ $task['id'] }}">
+				<tr id="t{{ $task->getId() }}">
 					<td>
 						{!! link_to(
-							env('PHABRICATOR_URL') . 'T' . $task['id'],
-							"#${task['id']} " . $task['title'],
+							env('PHABRICATOR_URL') . 'T' . $task->getId(),
+							'#' . $task->getId(). ' ' . $task->getTitle(),
 							[
 								'class' => 'title',
 								'target' => '_blank'
@@ -145,18 +145,18 @@
 						) !!}
 					</td>
 
-					<?php $priorityValue = Config::get('phabricator.MANIPHEST_PRIORITIES')[strtolower($task['priority'])] ?>
+					<?php $priorityValue = Config::get('phabricator.MANIPHEST_PRIORITIES')[strtolower($task->getPriority())] ?>
 					<td class="filter-backlog" data-column="priority" data-value="{{ $priorityValue }}">
 						<span class="priority hidden">{{ $priorityValue }}</span>
-						{{ $task['priority'] }}
+						{{ $task->getPriority() }}
 					</td>
-					<td class="points">{{ $task['story_points'] }}</td>
+					<td class="points">{{ $task->getPoints() }}</td>
 
-					<td class="assignee filter-backlog" data-column="assignee" data-value="{{ $task['assignee'] }}">
-						{{ $task['assignee']}}
+					<td class="assignee filter-backlog" data-column="assignee" data-value="{{ $task->getAssigneeName() }}">
+						{{ $task->getAssigneeName() }}
 					</td>
-					<td class="filter-backlog" data-column="status" data-value="{{ $task['status'] }}">
-						<span class="status status-label {{ $task['cssClass'] }}">{{ $task['status'] }}</span>
+					<td class="filter-backlog" data-column="status" data-value="{{ $task->getStatus() }}">
+						<span class="status status-label {{ $task->getCssClass() }}">{{ $task->getStatus() }}</span>
 					</td>
 				</tr>
 			@endforeach

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -6,6 +6,7 @@ use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\MinkExtension\Context\MinkContext;
 use PHPUnit_Framework_Assert as PHPUnit;
+use Phragile\TaskDataFetcher;
 
 /**
  * Defines application features from the specific context.
@@ -475,7 +476,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	private function getOrCreateTaskForSprint($sprintPHID)
 	{
 		$phabricator = App::make('phabricator');
-		$tasks = $phabricator->queryTasksByProject($sprintPHID);
+		$tasks = (new TaskDataFetcher($phabricator))->fetchProjectTasks($sprintPHID);
 
 		if ($tasks) return array_values($tasks)[0];
 

--- a/tests/unit/BurndownChartTest.php
+++ b/tests/unit/BurndownChartTest.php
@@ -4,6 +4,7 @@ use Phragile\BurndownChart;
 use Phragile\ClosedTimeByStatusFieldDispatcher;
 use Phragile\ClosedTimeByWorkboardDispatcher;
 use Phragile\ClosedTimeDispatcher;
+use Phragile\Task;
 
 class BurndownChartTest extends TestCase {
 
@@ -46,14 +47,30 @@ class BurndownChartTest extends TestCase {
 		'1' => [
 			'id' => 1,
 			'closed' => true,
-			'story_points' => 8
+			'points' => 8
 		],
 		'2' => [
 			'id' => 2,
 			'closed' => true,
-			'story_points' => 2
+			'points' => 2
 		]
 	];
+
+	/**
+	 * @before
+	 */
+	public function initDummyTasks()
+	{
+		$this->tasks = array_map(function($taskData)
+		{
+			return new Task(array_merge($taskData, [
+				'title' => 'A Task',
+				'priority' => 'Normal',
+				'status' => 'Open',
+				'assigneePHID' => null,
+			]));
+		}, $this->tasks);
+	}
 
 	private $closedColumnPHIDs = ['123abc', 'abc123'];
 
@@ -264,11 +281,15 @@ class BurndownChartTest extends TestCase {
 	public function testOpenTaskTransactionsAreIgnored()
 	{
 		$burndown = $this->mockWithTransactions(
-			['500' => [
+			['500' => new Task([
+				'title' => 'A Task',
+				'priority' => 'Normal',
 				'id' => 500,
+				'status' => 'Open',
 				'closed' => false,
-				'story_points' => 5,
-			]],
+				'assigneePHID' => null,
+				'points' => 5,
+			])],
 			['500' => [[ // this transaction's task is not closed and should be ignored
 				'transactionType' => 'status',
 				'oldValue' => 'open',

--- a/tests/unit/StatusByStatusFieldDispatcherTest.php
+++ b/tests/unit/StatusByStatusFieldDispatcherTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Phragile\StatusByStatusFieldDispatcher;
+
+class StatusByStatusFieldDispatcherTest extends TestCase {
+	public function taskWithCorrectStatusProvider()
+	{
+		return [
+			[
+				[
+					'fields' => [
+						'status' => ['value' => 'open'],
+						'ownerPHID' => null,
+					],
+					'attachments' => ['projects' => ['projectPHIDs' => []]]
+				],
+				'open',
+				false
+			],
+			[
+				[
+					'fields' => [
+						'status' => ['value' => 'resolved'],
+						'ownerPHID' => null,
+					],
+					'attachments' => ['projects' => ['projectPHIDs' => []]]
+				],
+				'resolved',
+				true
+			],
+			[
+				[
+					'fields' => [
+						'status' => ['value' => 'resolved'],
+						'ownerPHID' => null,
+					],
+					'attachments' => ['projects' => ['projectPHIDs' => [$this->reviewTagPHID]]]
+				],
+				'resolved',
+				true
+			],
+			[
+				[
+					'fields' => [
+						'status' => ['value' => 'open'],
+						'ownerPHID' => null,
+					],
+					'attachments' => ['projects' => ['projectPHIDs' => [$this->reviewTagPHID]]]
+				],
+				'patch to review',
+				false
+			],
+		];
+	}
+
+	private $reviewTagPHID = 'PHID-PROJ-1337';
+
+	/**
+	 * @dataProvider taskWithCorrectStatusProvider
+	 */
+	public function testReturnsCorrectStatus($rawTask, $status, $isClosed)
+	{
+		$statusDispatcher = new StatusByStatusFieldDispatcher($this->reviewTagPHID);
+
+		$this->assertSame($status, $statusDispatcher->getStatus($rawTask));
+		$this->assertSame($isClosed, $statusDispatcher->isClosed($rawTask));
+	}
+}

--- a/tests/unit/StatusByWorkboardDispatcherTest.php
+++ b/tests/unit/StatusByWorkboardDispatcherTest.php
@@ -102,6 +102,18 @@ class StatusByWorkboardDispatcherTest extends TestCase {
 		$this->assertTrue($dispatcher->isClosed($task));
 	}
 
+	public function testGivenIrrelevantTransaction_tasksStatusIsBasedOnProjectsDefaultColumn()
+	{
+		$sprint = $this->newSprint();
+		$task = ['id' => 'fooTask'];
+		$transaction = $this->getFirstTransaction();
+		$transaction['oldValue']['projectPHID'] = 'PHID-SOME-OTHER-PROJ-PHID';
+		$transaction['newValue']['projectPHID'] = 'PHID-SOME-OTHER-PROJ-PHID';
+		$dispatcher = $this->newDispatcher($sprint, ['fooTask' => [$transaction]]);
+		$this->assertEquals('backlog', $dispatcher->getStatus($task));
+		$this->assertFalse($dispatcher->isClosed($task));
+	}
+
 	private function getFirstTransaction()
 	{
 		return [

--- a/tests/unit/TaskDataProcessorTest.php
+++ b/tests/unit/TaskDataProcessorTest.php
@@ -1,0 +1,240 @@
+<?php
+
+use Phragile\StatusByStatusFieldDispatcher;
+use Phragile\TaskDataProcessor;
+
+class TaskDataProcessorTest extends TestCase
+{
+	public function testCreatesTasksCorrectly()
+	{
+		$statusDispatcher = new StatusByStatusFieldDispatcher('');
+		$tasks = (new TaskDataProcessor(
+			$statusDispatcher,
+			['ignored_columns' => [], 'ignore_estimates' => false]
+		))->process($this->taskRawData);
+
+		for ($i = 0; $i < count($this->taskRawData); $i++)
+		{
+			$rawTask = $this->taskRawData[$i];
+			$task = $tasks[$i];
+
+			$this->assertSame($rawTask['fields']['name'], $task->getTitle());
+			$this->assertSame($rawTask['fields']['priority']['name'], $task->getPriority());
+			$this->assertSame($rawTask['fields']['points'], $task->getPoints());
+			$this->assertSame($statusDispatcher->getStatus($rawTask), $task->getStatus());
+			$this->assertSame($rawTask['id'], $task->getId());
+			$this->assertSame($rawTask['fields']['ownerPHID'], $task->getAssigneePHID());
+		}
+	}
+
+	/**
+	 * This test is using a StatusByStatusFieldDispatcher since it is easier to set up even though the tested
+	 * functionality is supposed to be used for ignoring columns.
+	 */
+	public function testIgnoreToDoStatus()
+	{
+		$rawData = [
+			[
+				'id' => 1,
+				'fields' => [
+					'name' => 'To Do Task',
+					'priority' => ['name' => 'High'],
+					'status' => ['value' => 'To Do'],
+					'ownerPHID' => null,
+					'points' => 2,
+				],
+				'attachments' => ['projects' => ['projectPHIDs' => []]]
+			],
+			[
+				'id' => 2,
+				'fields' => [
+					'name' => 'Resolved Task',
+					'priority' => ['name' => 'High'],
+					'status' => ['value' => 'resolved'],
+					'ownerPHID' => null,
+					'points' => 3,
+				],
+				'attachments' => ['projects' => ['projectPHIDs' => []]]
+			]
+		];
+
+		$tasks = (new TaskDataProcessor(
+			new StatusByStatusFieldDispatcher(''),
+			['ignored_columns' => ['To Do'], 'ignore_estimates' => false]
+		))->process($rawData);
+		$this->assertCount(1, $tasks);
+		$this->assertSame('resolved', array_values($tasks)[0]->getStatus());
+	}
+
+	public function testGivenIgnoreEstimatesTrue_GiveEachTask1Point()
+	{
+		$statusDispatcher = new StatusByStatusFieldDispatcher('');
+		$tasks = (new TaskDataProcessor(
+			$statusDispatcher,
+			['ignored_columns' => [], 'ignore_estimates' => true]
+		))->process($this->taskRawData);
+
+		for ($i = 0; $i < count($this->taskRawData); $i++)
+		{
+			$this->assertSame(1, $tasks[$i]->getPoints());
+		}
+	}
+
+	private $taskRawData = [ // Results of a maniphest.search call
+		[
+			'id' => 325,
+			'type' => 'TASK',
+			'phid' => 'PHID-TASK-rl7r3g3kc3y2tbxlwsc2',
+			'fields' => [
+				'name' => 'task5',
+				'authorPHID' => 'PHID-USER-orako562kbdgbdwvteo7',
+				'ownerPHID' => null,
+				'status' => [
+					'value' => 'open',
+					'name' => 'Open',
+					'color' => null
+				],
+				'priority' => [
+					'value' => 90,
+					'subpriority' => 0,
+					'name' => 'Needs Triage',
+					'color' => 'violet'
+				],
+				'points' => '13',
+				'spacePHID' => null,
+				'dateCreated' => 1455539678,
+				'dateModified' => 1455548877,
+				'policy' => [
+					'view' => 'users',
+					'edit' => 'users'
+				],
+				'custom.WMDE:story_points' => 2,
+			],
+			'attachments' => ['projects' => ['projectPHIDs' => []]]
+		],
+		[
+			'id' => 324,
+			'type' => 'TASK',
+			'phid' => 'PHID-TASK-oiz3ted6g3yyux7homi6',
+			'fields' => [
+				'name' => 'task4',
+				'authorPHID' => 'PHID-USER-orako562kbdgbdwvteo7',
+				'ownerPHID' => null,
+				'status' => [
+					'value' => 'open',
+					'name' => 'Open',
+					'color' => null
+				],
+				'priority' => [
+					'value' => 90,
+					'subpriority' => 0,
+					'name' => 'Needs Triage',
+					'color' => 'violet'
+				],
+				'points' => null,
+				'spacePHID' => null,
+				'dateCreated' => 1455539134,
+				'dateModified' => 1455539981,
+				'policy' => [
+					'view' => 'users',
+					'edit' => 'users'
+				],
+				'custom.WMDE:story_points' => 3,
+			],
+			'attachments' => ['projects' => ['projectPHIDs' => []]]
+		],
+		[
+			'id' => 323,
+			'type' => 'TASK',
+			'phid' => 'PHID-TASK-dywm65et6m5s627svkap',
+			'fields' => [
+				'name' => 'task3',
+				'authorPHID' => 'PHID-USER-orako562kbdgbdwvteo7',
+				'ownerPHID' => null,
+				'status' => [
+					'value' => 'open',
+					'name' => 'Open',
+					'color' => null
+				],
+				'priority' => [
+					'value' => 90,
+					'subpriority' => 0,
+					'name' => 'Needs Triage',
+					'color' => 'violet'
+				],
+				'points' => null,
+				'spacePHID' => null,
+				'dateCreated' => 1455539110,
+				'dateModified' => 1455539966,
+				'policy' => [
+					'view' => 'users',
+					'edit' => 'users'
+				],
+				'custom.WMDE:story_points' => 2,
+			],
+			'attachments' => ['projects' => ['projectPHIDs' => []]]
+		],
+		[
+			'id' => 322,
+			'type' => 'TASK',
+			'phid' => 'PHID-TASK-7i5ytqz2cwrwysquktc5',
+			'fields' => [
+				'name' => 'task2',
+				'authorPHID' => 'PHID-USER-orako562kbdgbdwvteo7',
+				'ownerPHID' => 'PHID-USER-orako562kbdgbdwvteo7',
+				'status' => [
+					'value' => 'open',
+					'name' => 'Open',
+					'color' => null
+				],
+				'priority' => [
+					'value' => 90,
+					'subpriority' => 0,
+					'name' => 'Needs Triage',
+					'color' => 'violet'
+				],
+				'points' => null,
+				'spacePHID' => null,
+				'dateCreated' => 1455539073,
+				'dateModified' => 1455621580,
+				'policy' => [
+					'view' => 'users',
+					'edit' => 'users'
+				],
+				'custom.WMDE:story_points' => 24,
+			],
+			'attachments' => ['projects' => ['projectPHIDs' => []]]
+		],
+		[
+			'id' => 321,
+			'type' => 'TASK',
+			'phid' => 'PHID-TASK-e5t6hiqw6nqbrdr5agfk',
+			'fields' => [
+				'name' => 'task1',
+				'authorPHID' => 'PHID-USER-orako562kbdgbdwvteo7',
+				'ownerPHID' => null,
+				'status' => [
+					'value' => 'open',
+					'name' => 'Open',
+					'color' => null
+				],
+				'priority' => [
+					'value' => 90,
+					'subpriority' => 0,
+					'name' => 'Needs Triage',
+					'color' => 'violet'
+				],
+				'points' => null,
+				'spacePHID' => null,
+				'dateCreated' => 1455539048,
+				'dateModified' => 1455539922,
+				'policy' => [
+					'view' => 'users',
+					'edit' => 'users'
+				],
+				'custom.WMDE:story_points' => 8,
+			],
+			'attachments' => ['projects' => ['projectPHIDs' => []]]
+		]
+	];
+}

--- a/tests/unit/TaskListTest.php
+++ b/tests/unit/TaskListTest.php
@@ -1,10 +1,7 @@
 <?php
 
+use Phragile\Task;
 use Phragile\TaskList;
-use Phragile\StatusByStatusFieldDispatcher;
-use Phragile\StatusByWorkboardDispatcher;
-use Phragile\ProjectColumnRepository;
-use Phragile\SortedTransactionList;
 
 class TaskListTest extends TestCase {
 
@@ -38,185 +35,24 @@ class TaskListTest extends TestCase {
 		$i = 0;
 		$this->tasks = array_map(function($task) use(&$i)
 		{
-			return array_merge($task, [
+			return new Task(array_merge($task, [
 				'title' => 'a task',
 				'priority' => 'low',
-				'isClosed' => false,
+				'closed' => false,
 				'projectPHIDs' => ['x'],
-				'ownerPHID' => null,
+				'assigneePHID' => null,
 				'id' => ++$i,
 				'auxiliary' => [env('MANIPHEST_STORY_POINTS_FIELD') => $task['points']],
-			]);
+			]));
 		}, $this->tasks);
 	}
 
-	private $testSprint = null;
-	/**
-	 * @before
-	 */
-	public function initTestSprint()
-	{
-		$this->testSprint = new Sprint([
-			'phid' => 'PHID-123',
-		]);
-		$this->testSprint->project = new Project([
-			'closed_statuses' => 'done',
-		]);
-	}
 
 	public function testGetTasksPerStatus()
 	{
-		$taskList = $this->createTaskListWithStatusFieldDispatcher($this->tasks);
+		$taskList = new TaskList($this->tasks);
 
 		$this->assertSame(13, $taskList->getTasksPerStatus()['resolved']['points']);
 		$this->assertSame(8, $taskList->getTasksPerStatus()['open']['points']);
-	}
-
-	public function testIgnoreEstimates()
-	{
-		$taskList = $this->createTaskListIgnoringEstimatesWithStatusFieldDispatcher($this->tasks);
-
-		$this->assertSame(2, $taskList->getTasksPerStatus()['resolved']['points']);
-		$this->assertSame(1, $taskList->getTasksPerStatus()['open']['points']);
-	}
-
-	public function testGetTasksPerStatusWithWorkboardDispatcher()
-	{
-		$taskList = $this->createTaskListWithWorkboardDispatcher($this->tasks, $this->getProjectColumnTransactions());
-
-		$this->assertSame(5, $taskList->getTasksPerStatus()['done']['points']);
-		$this->assertSame(10, $taskList->getTasksPerStatus()['to do']['points']);
-	}
-
-	public function testOtherProjectTransactionsShouldBeIgnored()
-	{
-		$transactions = $this->getProjectColumnTransactions();
-		$transactions['5'] = [[
-			'transactionType' => 'projectcolumn',
-			'oldValue' => [
-				'columnPHIDs' => [],
-				'projectPHID' => 'PHID-456', // not identical to $this->testSprint->phid and should be ignored
-			],
-			'newValue' => [
-				'columnPHIDs' => [array_keys($this->workboardColumns)[2]],
-			]
-		]];
-		$taskList = $this->createTaskListWithWorkboardDispatcher(
-			$this->tasks,
-			$transactions
-		);
-
-		$this->assertSame(10, $taskList->getTasksPerStatus()['to do']['points']);
-	}
-
-	public function testIgnoreToDoColumn()
-	{
-		$taskList = $this->createTaskListWithWorkboardDispatcher($this->tasks, $this->getProjectColumnTransactions(), []);
-		$taskListIgnore = $this->createTaskListWithWorkboardDispatcher($this->tasks, $this->getProjectColumnTransactions(), ['to do']);
-
-		$this->assertFalse(isset($taskListIgnore->getTasksPerStatus()['to do']['points']));
-		$this->assertSame(10, $taskList->getTasksPerStatus()['to do']['points']);
-
-		$this->assertSame(30, $taskList->getTasksPerStatus()['total']['points']);
-		$this->assertSame(20, $taskListIgnore->getTasksPerStatus()['total']['points']);
-	}
-
-	public function testDefaultColumn()
-	{
-		$taskList = $this->createTaskListWithWorkboardDispatcher($this->tasks, $this->getProjectColumnTransactions(), []);
-		$this->assertSame(7, $taskList->getTasksPerStatus()['Backlog']['points']);
-
-		$this->testSprint->project->default_column = 'Incoming';
-		$taskList = $this->createTaskListWithWorkboardDispatcher($this->tasks, $this->getProjectColumnTransactions(), []);
-		$this->assertFalse(isset($taskList->getTasksPerStatus()['Backlog']['points']));
-		$this->assertSame(7, $taskList->getTasksPerStatus()['Incoming']['points']);
-	}
-
-	private function getProjectColumnTransactions()
-	{
-		return [
-			'1' => [[
-				'transactionType' => 'projectcolumn',
-				'oldValue' => [
-					'columnPHIDs' => ['anyNotClosed'],
-					'projectPHID' => $this->testSprint->phid,
-				],
-				'newValue' => [
-					'columnPHIDs' => [array_keys($this->workboardColumns)[0]],
-				]
-			]],
-			'2' => [[
-				'transactionType' => 'projectcolumn',
-				'oldValue' => [
-					'columnPHIDs' => ['anyNotClosed'],
-					'projectPHID' => $this->testSprint->phid,
-				],
-				'newValue' => [
-					'columnPHIDs' => [array_keys($this->workboardColumns)[1]],
-				]
-			]],
-			'3' => [[
-				'transactionType' => 'projectcolumn',
-				'oldValue' => [
-					'columnPHIDs' => [],
-					'projectPHID' => $this->testSprint->phid,
-				],
-				'newValue' => [
-					'columnPHIDs' => [array_keys($this->workboardColumns)[2]],
-				]
-			]],
-			'4' => [[
-				'transactionType' => 'projectcolumn',
-				'oldValue' => [
-					'columnPHIDs' => [],
-					'projectPHID' => $this->testSprint->phid,
-				],
-				'newValue' => [
-					'columnPHIDs' => [array_keys($this->workboardColumns)[2]],
-				]
-			]],
-			'5' => []
-		];
-	}
-
-	private $workboardColumns = [
-		'PHID-123abc' => 'wontfix',
-		'PHID-321cba' => 'done',
-		'PHID-abc123' => 'to do',
-	];
-
-	private function createTaskListWithStatusFieldDispatcher(array $tasks)
-	{
-		return new TaskList($tasks, new StatusByStatusFieldDispatcher('PHID-REVIEW123'), ['ignore_estimates' => false, 'ignored_columns' => []]);
-	}
-
-	private function createTaskListIgnoringEstimatesWithStatusFieldDispatcher(array $tasks)
-	{
-		return new TaskList($tasks, new StatusByStatusFieldDispatcher('PHID-REVIEW123'), ['ignore_estimates' => true, 'ignored_columns' => []]);
-	}
-
-	private function createTaskListWithWorkboardDispatcher(array $tasks, $transactions, array $ignored_columns = [])
-	{
-		$phabricatorAPI = $this->getMockBuilder('Phragile\PhabricatorAPI')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$phabricatorAPI->method('queryPHIDs')->will($this->returnCallback(function()
-		{
-			return array_map(function($column)
-			{
-				return ['name' => $column];
-			}, $this->workboardColumns);
-		}));
-
-		return new TaskList(
-			$tasks,
-			new StatusByWorkboardDispatcher(
-				$this->testSprint,
-				new SortedTransactionList($transactions),
-				new ProjectColumnRepository($this->testSprint->phid, $transactions, $phabricatorAPI)
-			),
-			['ignore_estimates' => false, 'ignored_columns' => $ignored_columns]
-		);
 	}
 }

--- a/tests/unit/TaskTest.php
+++ b/tests/unit/TaskTest.php
@@ -1,0 +1,95 @@
+<?php
+use Phragile\Task;
+
+class TaskTest extends TestCase {
+	private $taskFields = [
+		'title' => 'A task',
+		'priority' => 'High',
+		'points' => '13',
+		'status' => 'Open',
+		'closed' => true,
+		'id' => '42',
+		'assigneePHID' => 'PHID-1337',
+	];
+
+	public function incompleteAttributes()
+	{
+		$attributeCombinations = [];
+
+		foreach (array_keys($this->taskFields) as $key)
+		{
+			$combination = $this->taskFields;
+			unset($combination[$key]);
+			$attributeCombinations[] = [$combination];
+		}
+
+		return $attributeCombinations;
+	}
+
+	/**
+	 * @dataProvider incompleteAttributes
+	 */
+	public function testThrowsExceptionWithMissingAttributes($incompleteAttributes)
+	{
+		$this->setExpectedException(InvalidArgumentException::class);
+		new Task($incompleteAttributes);
+	}
+
+	public function testHasTitle()
+	{
+		$task = new Task($this->taskFields);
+		$this->assertSame($task->getTitle(), $this->taskFields['title']);
+	}
+
+	public function testHasPriority()
+	{
+		$task = new Task($this->taskFields);
+		$this->assertSame($task->getPriority(), $this->taskFields['priority']);
+	}
+
+	public function testHasPoints()
+	{
+		$task = new Task($this->taskFields);
+		$this->assertSame($task->getPoints(), $this->taskFields['points']);
+	}
+
+	public function testHasStatus()
+	{
+		$task = new Task($this->taskFields);
+		$this->assertSame($task->getStatus(), $this->taskFields['status']);
+	}
+
+	public function testHasClosedField()
+	{
+		$task = new Task($this->taskFields);
+		$this->assertSame($task->isClosed(), $this->taskFields['closed']);
+	}
+
+	public function testHasId()
+	{
+		$task = new Task($this->taskFields);
+		$this->assertSame($task->getId(), $this->taskFields['id']);
+	}
+
+	public function testHasAssigneePHID()
+	{
+		$task = new Task($this->taskFields);
+		$this->assertSame($task->getAssigneePHID(), $this->taskFields['assigneePHID']);
+	}
+
+	public function testCanSetAndGetAssignee()
+	{
+		$task = new Task($this->taskFields);
+		$assignee = 'Meh';
+		$task->setAssigneeName($assignee);
+		$this->assertSame($assignee, $task->getAssigneeName());
+	}
+
+	public function testCanSetAndGetCssClass()
+	{
+		$task = new Task($this->taskFields);
+		$class = 'foo';
+		$task->setCssClass($class);
+		$this->assertSame($class, $task->getCssClass());
+	}
+}


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T127179

Things this patch includes:
* use `maniphest.search` instead of `maniphest.query´
* introduce a `TaskDataFetcher` that replaces what were previously API calls to fetch tasks
* introduce a `TaskDataProcessor` (anyone got an idea for a better name?) that creates a list of `Task` objects from the output of `TaskDataFetcher`
* introduce `Task` which is a value object for tasks
* remove a bunch of stuff from `TaskList` and `TaskListTest` and put it where it belongs (mostly `TaskDataProcessor`, `StatusByWorkboardDispatcher` and their tests)
* test some more things
* `StatusByStatusFieldDispatcher` got a little bit uglier since information whether a task is closed is not included in `maniphest.search` so it now checks for a list of hardcoded statuses which might be silly

... whew, did I just rewrite Phragile?

These commits should probably be squashed before merging.