### PR TITLE
Maniphest.query -> maniphest.search migration script

### DIFF
--- a/app/Console/Commands/MigrateSnapshots.php
+++ b/app/Console/Commands/MigrateSnapshots.php
@@ -1,0 +1,30 @@
+<?php namespace App\Console\Commands;
+
+use App\Console\Commands\Lib\SnapshotDataConverter;
+use Illuminate\Console\Command;
+use SprintSnapshot;
+
+class MigrateSnapshots extends Command {
+
+	protected $name = 'snapshots:migrate';
+	protected $description = 'This command migrates all snapshots from the maniphest.query format to maniphest.search JSON.';
+
+	public function fire()
+	{
+		foreach (SprintSnapshot::all() as $snapshot)
+		{
+			$snapshotData = json_decode($snapshot->data, true);
+			if ($snapshotData['tasks'] && $this->isManiphestQueryFormat($snapshotData['tasks']))
+			{
+				$snapshotData['tasks'] = (new SnapshotDataConverter($snapshotData['tasks']))->convert();
+				$snapshot->data = json_encode($snapshotData);
+				$snapshot->save();
+			}
+		}
+	}
+
+	private function isManiphestQueryFormat(array $taskData)
+	{
+		return array_keys($taskData) !== range(0, count($taskData) - 1);
+	}
+}

--- a/app/Console/Commands/lib/SnapshotDataConverter.php
+++ b/app/Console/Commands/lib/SnapshotDataConverter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Console\Commands\Lib;
+
+class SnapshotDataConverter {
+	private $taskData;
+
+	public function __construct(array $taskData)
+	{
+		$this->taskData = $taskData;
+	}
+
+	public function convert()
+	{
+		return array_values(array_map(array($this, 'convertToManiphestSearchResponse'), $this->taskData));
+	}
+
+	private function convertToManiphestSearchResponse(array $task)
+	{
+		$points = isset($task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')]) ? $task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')] : 0;
+		return [
+			'id' => (int)$task['id'],
+			'type' => 'TASK',
+			'phid' => $task['phid'],
+			'fields' => array_merge(
+				$this->convertCustomFields($task), [
+				'name' => $task['title'],
+				'authorPHID' => $task['authorPHID'],
+				'ownerPHID' => $task['ownerPHID'],
+				'status' => [
+					'value' => $task['status'],
+					'name' => null,
+					'color' => null
+				],
+				'priority' => [
+					'value' => null,
+					'subpriority' => null,
+					'name' => $task['priority'],
+				],
+				'points' => $points,
+			]),
+			'attachments' => ['projects' => ['projectPHIDs' => $task['projectPHIDs']]]
+		];
+	}
+
+	private function convertCustomFields(array $task)
+	{
+		$fields = [];
+
+		foreach ($task['auxiliary'] as $name => $value)
+		{
+			$fields['custom.' . $this->strAfterSecondColon($name)] = $value;
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Format of old custom field was e.g. std:maniphest:WMDE:story_points or isdc:sprint:storypoints.
+	 * Equivalent new format would be custom.WMDE_story_points or custom.storypoints.
+	 * @param string $s
+	 * @return string
+	 */
+	private function strAfterSecondColon($s)
+	{
+		return implode(':',
+			array_slice(explode(':', $s), 2)
+		);
+	}
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,6 +13,7 @@ class Kernel extends ConsoleKernel {
 	protected $commands = [
 		'App\Console\Commands\Inspire',
 		'App\Console\Commands\CreateSnapshots',
+		'App\Console\Commands\MigrateSnapshots',
 	];
 
 	/**

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -1,12 +1,12 @@
 <?php
 
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
-use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\MinkExtension\Context\MinkContext;
 use PHPUnit_Framework_Assert as PHPUnit;
+use Phragile\StatusByStatusFieldDispatcher;
 use Phragile\TaskDataFetcher;
+use Phragile\TaskDataProcessor;
 
 /**
  * Defines application features from the specific context.
@@ -18,6 +18,8 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	private $selectedTask;
 	private $numberOfSprints;
 	private $numberOfProjects;
+	private $testSnapshot;
+	private $testSnapshotTitle;
 
 	public function __construct(array $params)
 	{
@@ -579,4 +581,31 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	{
 		$this->assertPageContainsText('Sprints ' . ($this->numberOfSprints + $number));
 	}
+
+    /**
+     * @Given there is a snapshot in the maniphest.query format
+     */
+    public function thereIsASnapshotInTheManiphestQueryFormat()
+    {
+		$this->testSnapshotTitle = '[Phragile] Migration script for old snapshots';
+        $this->testSnapshot = new SprintSnapshot();
+		$this->testSnapshot->data = '{"transactions":[],"tasks":{"PHID-123123":{"id":"127180","phid":"PHID-TASK-4kvxc4re6xrshgxtfajl","authorPHID":"PHID-USER-t4sxxglz6yyrgxeib43i","ownerPHID":"PHID-USER-5dv7dcltvyvolwzbm2af","ccPHIDs":["PHID-USER-5dv7dcltvyvolwzbm2af","PHID-USER-fn7qnpccfbitivgtw2rt","PHID-USER-lltif2drabccdkwhet7x"],"status":"open","statusName":"Open","isClosed":false,"priority":"High","priorityColor":"red","title":"'
+		. $this->testSnapshotTitle
+		. '","description":"Snapshot data needs to be migrated to a new format since we are going to abandon maniphest.query in favor of maniphest.search.","projectPHIDs":["PHID-PROJ-ptnfbfyq36kkebaxugcz","PHID-PROJ-tazsyaydzpbd643tderv","PHID-PROJ-knyj2bgnrkrwu72n27bg"],"uri":"https:\/\/phabricator.wikimedia.org\/T127180","auxiliary":{"std:maniphest:security_topic":"default",'
+		. '"' . env('MANIPHEST_STORY_POINTS_FIELD') . '":12'
+		. '},"objectName":"T127180","dateCreated":"1455716487","dateModified":"1455880296","dependsOnTaskPHIDs":["PHID-TASK-tuaxg2zcafwmpoe2d5ys"]}}}';
+		$this->testSnapshot->save();
+    }
+
+    /**
+     * @Then the snapshot should be in the maniphest.search format
+     */
+    public function theSnapshotShouldBeInTheManiphestSearchFormat()
+    {
+        $snapshotTaskTitle = '[Phragile] Migration script for old snapshots';
+		$taskProcessor = (new TaskDataProcessor(new StatusByStatusFieldDispatcher(''), ['ignore_estimates' => false, 'ignored_columns' => []]));
+		$tasks = $taskProcessor->process(json_decode($this->testSnapshot->fresh()->data, true)['tasks']);
+		PHPUnit::assertSame($snapshotTaskTitle, $tasks[0]->getTitle());
+		PHPUnit::assertSame(12, $tasks[0]->getPoints());
+    }
 }

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -582,30 +582,30 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		$this->assertPageContainsText('Sprints ' . ($this->numberOfSprints + $number));
 	}
 
-    /**
-     * @Given there is a snapshot in the maniphest.query format
-     */
-    public function thereIsASnapshotInTheManiphestQueryFormat()
-    {
+	/**
+	 * @Given there is a snapshot in the maniphest.query format
+	 */
+	public function thereIsASnapshotInTheManiphestQueryFormat()
+	{
 		$this->testSnapshotTitle = '[Phragile] Migration script for old snapshots';
-        $this->testSnapshot = new SprintSnapshot();
+		$this->testSnapshot = new SprintSnapshot();
 		$this->testSnapshot->data = '{"transactions":[],"tasks":{"PHID-123123":{"id":"127180","phid":"PHID-TASK-4kvxc4re6xrshgxtfajl","authorPHID":"PHID-USER-t4sxxglz6yyrgxeib43i","ownerPHID":"PHID-USER-5dv7dcltvyvolwzbm2af","ccPHIDs":["PHID-USER-5dv7dcltvyvolwzbm2af","PHID-USER-fn7qnpccfbitivgtw2rt","PHID-USER-lltif2drabccdkwhet7x"],"status":"open","statusName":"Open","isClosed":false,"priority":"High","priorityColor":"red","title":"'
 		. $this->testSnapshotTitle
 		. '","description":"Snapshot data needs to be migrated to a new format since we are going to abandon maniphest.query in favor of maniphest.search.","projectPHIDs":["PHID-PROJ-ptnfbfyq36kkebaxugcz","PHID-PROJ-tazsyaydzpbd643tderv","PHID-PROJ-knyj2bgnrkrwu72n27bg"],"uri":"https:\/\/phabricator.wikimedia.org\/T127180","auxiliary":{"std:maniphest:security_topic":"default",'
 		. '"' . env('MANIPHEST_STORY_POINTS_FIELD') . '":12'
 		. '},"objectName":"T127180","dateCreated":"1455716487","dateModified":"1455880296","dependsOnTaskPHIDs":["PHID-TASK-tuaxg2zcafwmpoe2d5ys"]}}}';
 		$this->testSnapshot->save();
-    }
+	}
 
-    /**
-     * @Then the snapshot should be in the maniphest.search format
-     */
-    public function theSnapshotShouldBeInTheManiphestSearchFormat()
-    {
-        $snapshotTaskTitle = '[Phragile] Migration script for old snapshots';
+	/**
+	 * @Then the snapshot should be in the maniphest.search format
+	 */
+	public function theSnapshotShouldBeInTheManiphestSearchFormat()
+	{
+		$snapshotTaskTitle = '[Phragile] Migration script for old snapshots';
 		$taskProcessor = (new TaskDataProcessor(new StatusByStatusFieldDispatcher(''), ['ignore_estimates' => false, 'ignored_columns' => []]));
 		$tasks = $taskProcessor->process(json_decode($this->testSnapshot->fresh()->data, true)['tasks']);
 		PHPUnit::assertSame($snapshotTaskTitle, $tasks[0]->getTitle());
 		PHPUnit::assertSame(12, $tasks[0]->getPoints());
-    }
+	}
 }

--- a/tests/acceptance/sprint_snapshots.feature
+++ b/tests/acceptance/sprint_snapshots.feature
@@ -38,3 +38,8 @@ Feature: Sprint Snapshots
     Given I know the number of snapshots
     When I execute artisan "snapshots:create"
     Then I should have created one snapshot for each sprint
+
+  Scenario: Migrate snapshots from maniphest.query to maniphest.search
+    Given there is a snapshot in the maniphest.query format
+    When I execute artisan "snapshots:migrate"
+    Then the snapshot should be in the maniphest.search format

--- a/tests/unit/SnapshotDataConverterTest.php
+++ b/tests/unit/SnapshotDataConverterTest.php
@@ -1,0 +1,102 @@
+<?php
+use App\Console\Commands\Lib\SnapshotDataConverter;
+
+class SnapshotDataConverterTest extends TestCase {
+	public function testGivenManiphestQueryData_ReturnsManiphestSearchData()
+	{
+		$customField = 'WMDE:storypoints';
+		$this->queryTaskData['0']['auxiliary']["std:maniphest:$customField"] = 'foo';
+		$this->queryTaskData['0']['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')] = '5';
+		$convertedData = (new SnapshotDataConverter($this->queryTaskData))->convert();
+
+		$this->assertSame($this->searchTaskData[0]['id'], $convertedData[0]['id']);
+		$this->assertSame($this->searchTaskData[0]['phid'], $convertedData[0]['phid']);
+		$this->assertSame($this->searchTaskData[0]['fields']['name'], $convertedData[0]['fields']['name']);
+		$this->assertSame($this->searchTaskData[0]['fields']['authorPHID'], $convertedData[0]['fields']['authorPHID']);
+		$this->assertSame($this->searchTaskData[0]['fields']['ownerPHID'], $convertedData[0]['fields']['ownerPHID']);
+		$this->assertSame($this->searchTaskData[0]['fields']['status']['value'], $convertedData[0]['fields']['status']['value']);
+		$this->assertSame($this->searchTaskData[0]['fields']['priority']['name'], $convertedData[0]['fields']['priority']['name']);
+		$this->assertSame($this->searchTaskData[0]['fields']['points'], $convertedData[0]['fields']['points']);
+		$this->assertSame('foo', $convertedData[0]['fields']["custom.$customField"]);
+		$this->assertSame($this->queryTaskData['0']['projectPHIDs'], $convertedData[0]['attachments']['projects']['projectPHIDs']);
+	}
+
+	private $queryTaskData = [
+		'0' => [
+			'id' => '127180',
+			'phid' => 'PHID-TASK-4kvxc4re6xrshgxtfajl',
+			'authorPHID' => 'PHID-USER-t4sxxglz6yyrgxeib43i',
+			'ownerPHID' => 'PHID-USER-5dv7dcltvyvolwzbm2af',
+			'ccPHIDs' => [
+				'PHID-USER-5dv7dcltvyvolwzbm2af',
+				'PHID-USER-fn7qnpccfbitivgtw2rt',
+				'PHID-USER-lltif2drabccdkwhet7x'
+			],
+			'status' => 'open',
+			'statusName' => 'Open',
+			'isClosed' => false,
+			'priority' => 'High',
+			'priorityColor' => 'red',
+			'title' => '[Phragile] Migration script for old snapshots',
+			'description' => 'Snapshot data needs to be migrated to a new format since we are going to abandon maniphest.query in favor of maniphest.search.',
+			'projectPHIDs' => [
+				'PHID-PROJ-ptnfbfyq36kkebaxugcz',
+				'PHID-PROJ-tazsyaydzpbd643tderv',
+				'PHID-PROJ-knyj2bgnrkrwu72n27bg'
+			],
+			'uri' => 'https://phabricator.wikimedia.org/T127180',
+			'auxiliary' => [
+				'std:maniphest:security_topic' => 'default',
+			],
+			'objectName' => 'T127180',
+			'dateCreated' => '1455716487',
+			'dateModified' => '1455880296',
+			'dependsOnTaskPHIDs' => [
+				'PHID-TASK-tuaxg2zcafwmpoe2d5ys'
+			]
+		]
+	];
+
+	private $searchTaskData = [
+		[
+			'id' => 127180,
+			'type' => 'TASK',
+			'phid' => 'PHID-TASK-4kvxc4re6xrshgxtfajl',
+			'fields' => [
+				'name' => '[Phragile] Migration script for old snapshots',
+				'authorPHID' => 'PHID-USER-t4sxxglz6yyrgxeib43i',
+				'ownerPHID' => 'PHID-USER-5dv7dcltvyvolwzbm2af',
+				'status' => [
+					'value' => 'open',
+					'name' => 'Open',
+					'color' => null
+				],
+				'priority' => [
+					'value' => 80,
+					'subpriority' => -8.5312317223004e-5,
+					'name' => 'High',
+					'color' => 'red'
+				],
+				'points' => '5',
+				'spacePHID' => 'PHID-SPCE-6l6g5p53yi3mypnlpxjw',
+				'dateCreated' => 1455716487,
+				'dateModified' => 1455880296,
+				'policy' => [
+					'view' => 'public',
+					'edit' => 'users'
+				],
+				'custom.security_topic' => 'default',
+				'custom.external_reference' => null
+			],
+			'attachments' => [
+				'projects' => [
+					'projectPHIDs' => [
+						'PHID-PROJ-ptnfbfyq36kkebaxugcz',
+						'PHID-PROJ-tazsyaydzpbd643tderv',
+						'PHID-PROJ-knyj2bgnrkrwu72n27bg'
+					]
+				]
+			]
+		]
+	];
+}


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T127180

Can be executed via `php artisan snapshots:migrate`.
The tests look a bit ugly since those JSON strings/objects are so awkward to move around.