### PR TITLE
fix story point test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ PHABRICATOR_URL=http://phabricator.dev/
 PHRAGILE_BOT_API_TOKEN=
 
 # Name of your custom field for story points in Maniphest
-MANIPHEST_STORY_POINTS_FIELD=std:maniphest:yourcompany:story_points
+MANIPHEST_STORY_POINTS_FIELD=yourcompany:story_points
 
 # When using sprint extension https://github.com/wikimedia/phabricator-extensions-Sprint
 #MANIPHEST_STORY_POINTS_FIELD=isdc:sprint:storypoints

--- a/app/Phragile/PhabricatorAPI.php
+++ b/app/Phragile/PhabricatorAPI.php
@@ -74,7 +74,7 @@ class PhabricatorAPI {
 				'projectPHIDs' => [$projectPHID],
 				'priority' => $this->priorities[$task['priority']],
 				'auxiliary' => [
-					env('MANIPHEST_STORY_POINTS_FIELD') => $task['points']
+					'std:maniphest:'.env('MANIPHEST_STORY_POINTS_FIELD') => $task['points']
 				]
 			]
 		);

--- a/build/phragile.env
+++ b/build/phragile.env
@@ -13,5 +13,5 @@ OAUTH_CLIENT_ID=PHID-OASC-jl4uwp5sywuxnsncbpm6
 OAUTH_CLIENT_SECRET=z3vmaeipi4yiyz2sl3qnzsy752pcx32i
 PHABRICATOR_URL=http://phabricator.test:8080/
 PHRAGILE_BOT_API_TOKEN=api-6nqd63uay2jsgfjsaesyxo3c7mnt
-MANIPHEST_STORY_POINTS_FIELD=std:maniphest:WMDE:story_points
+MANIPHEST_STORY_POINTS_FIELD=WMDE:story_points
 PHRAGILE_ADMINS=Admin

--- a/resources/views/sprint/view.blade.php
+++ b/resources/views/sprint/view.blade.php
@@ -146,8 +146,8 @@
 					</td>
 
 					<?php $priorityValue = Config::get('phabricator.MANIPHEST_PRIORITIES')[strtolower($task->getPriority())] ?>
-					<td class="filter-backlog" data-column="priority" data-value="{{ $priorityValue }}">
-						<span class="priority hidden">{{ $priorityValue }}</span>
+					<td class="filter-backlog priority" data-column="priority" data-value="{{ $priorityValue }}">
+						<span class="hidden">{{ $priorityValue }}</span>
 						{{ $task->getPriority() }}
 					</td>
 					<td class="points">{{ $task->getPoints() }}</td>

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -224,17 +224,18 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	}
 
 	/**
-	 * @Given it has the following tasks for the :sprint Sprint:
+	 * @Given :sprint has a task with :title :priority and :points
 	 */
-	public function itHasTheFollowingTasks($sprint, \Behat\Gherkin\Node\TableNode $table)
+	public function sprintHasATaskWith($sprint, $title, $priority, $points)
 	{
 		$sprintPHID = Sprint::where('title', $sprint)->first()->phid;
 		$phabricator = App::make('phabricator');
 
-		foreach ($table->getHash() as $task)
-		{
-			$phabricator->createTask($sprintPHID, $task);
-		}
+		$this->selectedTask = $phabricator->createTask($sprintPHID, [
+			'title' => $title,
+			'priority' => $priority,
+			'points' => $points
+		]);
 	}
 
 	/**
@@ -506,6 +507,30 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	public function iShouldSeeMyNameInTheTaskSRowOfTheSprintBacklog()
 	{
 		$this->assertElementContains('#t' . $this->selectedTask['id'], $this->params['phabricator_username']);
+	}
+
+	/**
+	 * @Then I should see the task with :title as title
+	 */
+	public function iShouldSeeTheTaskWithTitle($title)
+	{
+		$this->assertElementContains('#t' . $this->selectedTask['id'] . ' .title', $title);
+	}
+
+	/**
+	 * @Then I should see the task with :priority as priority
+	 */
+	public function iShouldSeeTheTaskWithPriority($priority)
+	{
+		$this->assertElementContains('#t' . $this->selectedTask['id'] . ' .priority', $priority);
+	}
+
+	/**
+	 * @Then I should see the task with :points story points
+	 */
+	public function iShouldSeeTheTaskWithStoryPoints($storyPoints)
+	{
+		$this->assertElementContains('#t' . $this->selectedTask['id'] . ' .points', $storyPoints);
 	}
 
 	/**

--- a/tests/acceptance/sprint_overview.feature
+++ b/tests/acceptance/sprint_overview.feature
@@ -6,18 +6,17 @@ Feature: Sprint Overview
   Background:
     Given a sprint "Sprint 42" exists for the "Wikidata" project
 
-  Scenario: Sprint Backlog
-    Given it has the following tasks for the "Sprint 42" sprint:
+  Scenario Outline: See tasks on the Sprint Backlog
+    Given "Sprint 42" has a task with "<title>" "<priority>" and "<points>"
+    When I go to the "Sprint 42" sprint overview
+    Then I should see the task with "<title>" as title
+    And I should see the task with "<priority>" as priority
+    And I should see the task with "<points>" story points
+
+    Examples:
       | title         | priority |  points |
       | Fix things    | high     |  13     |
       | Implement XYZ | low      |  8      |
-    When I go to the "Sprint 42" sprint overview
-    Then I should see "Fix things"
-    And I should see "Implement XYZ"
-    And I should see "High"
-    And I should see "Low"
-    And I should see "13"
-    And I should see "8"
 
   Scenario: Assignees in Sprint Backlog
     Given I am logged in


### PR DESCRIPTION
The old test passed although story points could not be retrieved due to the fact, that the tested text for the points was found elsewhere on the page. ( e.g. like in `#13` before the task title )

This PR fixes that by introducing a new test and adjusting the story point settings in the test environment as well as in the default config file.

https://phabricator.wikimedia.org/T128726