### PR TITLE
Show assignees in sprint backlog table

### DIFF
--- a/app/Phragile/AssigneeRepository.php
+++ b/app/Phragile/AssigneeRepository.php
@@ -11,7 +11,7 @@ class AssigneeRepository {
 
 	/**
 	 * @param PhabricatorAPI $phabricator
-	 * @param array[] $tasks
+	 * @param Task[] $tasks
 	 */
 	public function __construct(PhabricatorAPI $phabricator, array $tasks)
 	{
@@ -21,11 +21,15 @@ class AssigneeRepository {
 		);
 	}
 
+	/**
+	 * @param Task[] $tasks
+	 * @return string[]
+	 */
 	private function extractUniqueAssignees(array $tasks)
 	{
-		return array_unique(array_map(function($task)
+		return array_unique(array_map(function(Task $task)
 		{
-			return $task['ownerPHID'];
+			return $task->getAssigneePHID();
 		}, $tasks));
 	}
 
@@ -49,4 +53,5 @@ class AssigneeRepository {
 	{
 		return isset($this->assignees[$phid]['userName']) ? $this->assignees[$phid]['userName'] : null;
 	}
+
 }

--- a/app/Phragile/Factory/SprintDataFactory.php
+++ b/app/Phragile/Factory/SprintDataFactory.php
@@ -17,7 +17,6 @@ use Phragile\Task;
 
 class SprintDataFactory {
 	private $sprint = null;
-	private $tasks = [];
 	private $transactions = [];
 	private $phabricatorAPI = null;
 
@@ -71,7 +70,7 @@ class SprintDataFactory {
 
 	public function getSprintBacklog()
 	{
-		$assignees = new AssigneeRepository($this->phabricatorAPI, $this->tasks);
+		$assignees = new AssigneeRepository($this->phabricatorAPI, $this->taskList->getTasks());
 
 		return array_map(function(Task $task) use($assignees)
 		{

--- a/tests/unit/AssigneeRepositoryTest.php
+++ b/tests/unit/AssigneeRepositoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Phragile\AssigneeRepository;
+use Phragile\PhabricatorAPI;
+use Phragile\Task;
+
+/**
+ * @covers Phragile\AssigneeRepository
+ */
+class AssigneeRepositoryTest extends PHPUnit_Framework_TestCase {
+
+	private $users = [
+		'PHID-USER-abc666' => 'Dummy User',
+	];
+
+	private function newPhabricatorAPI()
+	{
+		$phabricatorAPI = $this->getMockBuilder(PhabricatorAPI::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$phabricatorAPI->method('getUserData')->will($this->returnCallback(function()
+		{
+			return array_map(function($phid)
+			{
+				return ['phid' => $phid, 'userName' => $this->users[$phid]];
+			}, array_keys($this->users));
+		}));
+		return $phabricatorAPI;
+	}
+
+	private function newAssigneeRepository()
+	{
+		$tasks = [
+			new Task([
+				'id' => '123',
+				'title' => 'Simple Task',
+				'priority' => 'Normal',
+				'points' => 1,
+				'status' => 'Doing',
+				'closed' => false,
+				'assigneePHID' => 'PHID-USER-abc666'
+			]),
+		];
+		return new AssigneeRepository($this->newPhabricatorAPI(), $tasks);
+	}
+
+	public function testGivenPhidOfNotExistingUser_getNameReturnsNull()
+	{
+		$repository = $this->newAssigneeRepository();
+		$this->assertNull($repository->getName('PHID-USER-no-such-user'));
+	}
+
+	public function testGivenPhidOfExistingUser_getNameReturnsName()
+	{
+		$repository = $this->newAssigneeRepository();
+		$this->assertEquals('Dummy User', $repository->getName('PHID-USER-abc666'));
+	}
+
+}


### PR DESCRIPTION
Task: https://phabricator.wikimedia.org/T128717

Along with https://github.com/wmde/phragile/pull/215 fetching assignees got kind of broken. This does not become obvious when there are only 100 or fewer Phabricator users, that's why it hasn't been noticed by already existing Behat test.

Namely `SprintDataFactory` has been always passing `AssigneeRepository` an empty array, which the repository in turn used in Phabricator API query. When given empty list of user PHIDs API returns all users but truncates the list to first 100. In the test environment there are only few users, so the repository always got needed user but in the production environment this bug results with showing no assignees, see below (at least some of those tasks has already an user assigned):
![phragile-no-assignees](https://cloud.githubusercontent.com/assets/3524114/13493312/adc38206-e13d-11e5-96ee-519126f07606.png)
