### PR TITLE
Use correct task count in sprint snapshots

### DIFF
--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -115,7 +115,7 @@ class Sprint extends Eloquent {
 			'sprint_id' => $this->id,
 			'data' => json_encode($data),
 			'total_points' => $sumOfTasks['total']['points'],
-			'task_count' => count($sumOfTasks['total']['tasks']),
+			'task_count' => $sumOfTasks['total']['tasks'],
 		]);
 	}
 


### PR DESCRIPTION
This would prevent a bug reported in https://phabricator.wikimedia.org/T128594 from appearing in sprints closed after this patch is deployed.

tl;dr: `task_count` field of the snapshot has always been set to 1.
When not using story points estimates, burn down chart's remaining line and burn up chart's scope line of finished sprints are based on the task count defined in the snapshot (as the sprint has finished, no "live" data is fetched from Phabricator).
Among all changes in https://github.com/wmde/phragile/pull/215 setting `task_count` of the snapshot got broken. Dude who merged that PR was too blind to have noticed this problem.

This fix will of course not affect already existing snapshots. Task counts of those should be adjusted, I am afraid, manually.

I'd like to have this covered by unit test. Problem is that method creating a snapshots relies heavily on the global state (per `App:make('phabricator')`. This got me thinking if the `createSnapshot` method really belong to `Sprint` class.
Thus no test for now but I'd like get back to it rather soon.