### PR TITLE
improved snapshot script to handle big snapshot data

### DIFF
--- a/app/Console/Commands/MigrateSnapshots.php
+++ b/app/Console/Commands/MigrateSnapshots.php
@@ -2,6 +2,7 @@
 
 use App\Console\Commands\Lib\SnapshotDataConverter;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
 use SprintSnapshot;
 
 class MigrateSnapshots extends Command {
@@ -11,20 +12,64 @@ class MigrateSnapshots extends Command {
 
 	public function fire()
 	{
-		foreach (SprintSnapshot::all() as $snapshot)
-		{
-			$snapshotData = json_decode($snapshot->data, true);
-			if ($snapshotData['tasks'] && $this->isManiphestQueryFormat($snapshotData['tasks']))
-			{
-				$snapshotData['tasks'] = (new SnapshotDataConverter($snapshotData['tasks']))->convert();
-				$snapshot->data = json_encode($snapshotData);
-				$snapshot->save();
+		$snapshotCount = SprintSnapshot::count();
+		$batchSize = intval($this->input->getOption('batchSize'));
+
+		if (!$this->input->getOption('force')) {
+			$confirmation = $this->confirm('Do you really want to migrate ' . $snapshotCount . ' snapshots in batches of ' . $batchSize . '?');
+			if ( !$confirmation) {
+				$this->line('Migration aborted.');
+				return;
 			}
 		}
+
+		$this->line('Migration in progress:');
+		$i = 0;
+		while (count($snapshots = $this->getSnapshotsPart($batchSize, $batchSize * $i)) !== 0) {
+			foreach ($snapshots as $snapshot)
+			{
+				$snapshotData = json_decode($snapshot->data, true);
+				if ($snapshotData['tasks'] && $this->isManiphestQueryFormat($snapshotData['tasks']))
+				{
+					$snapshotData['tasks'] = (new SnapshotDataConverter($snapshotData['tasks']))->convert();
+					$snapshot->data = json_encode($snapshotData);
+					$snapshot->save();
+				}
+			}
+			$i++;
+			$this->line($this->getMigrationProgress($batchSize, $i, $snapshotCount) . '%');
+		}
+		$this->line('Migration finished!');
+	}
+
+	private function getMigrationProgress( $batchSize, $iteration, $snapshotCount)
+	{
+		if ($batchSize * $iteration >= $snapshotCount) {
+			return 100;
+		}
+		return round($batchSize / $snapshotCount * $iteration, 2) * 100;
+	}
+
+	private function getSnapshotsPart($limit, $offset)
+	{
+		return SprintSnapshot::take($limit)->skip($offset)->get();
 	}
 
 	private function isManiphestQueryFormat(array $taskData)
 	{
 		return array_keys($taskData) !== range(0, count($taskData) - 1);
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return [
+			['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production.'],
+			['batchSize', null, InputOption::VALUE_OPTIONAL, 'The number of snapshots to migrate per iteration.', 100],
+		];
 	}
 }

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -633,6 +633,18 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		PHPUnit::assertSame(12, $tasks[0]->getPoints());
 	}
 
+	/**
+	 * @Then the snapshot should still be in the maniphest.query format
+	 */
+	public function theSnapshotShouldStillBeInTheManiphestQueryFormat()
+	{
+		$snapshotTaskTitle = '[Phragile] Migration script for old snapshots';
+		$snapshot = json_decode($this->testSnapshot->fresh()->data, true);
+		$task = array_shift($snapshot['tasks']);
+		PHPUnit::assertSame($snapshotTaskTitle, $task['title']);
+		PHPUnit::assertSame(12, $task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')]);
+	}
+
 	private function getManiphestQuerySnapshotData()
 	{
 		return '{

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -7,6 +7,7 @@ use PHPUnit_Framework_Assert as PHPUnit;
 use Phragile\StatusByStatusFieldDispatcher;
 use Phragile\TaskDataFetcher;
 use Phragile\TaskDataProcessor;
+use Symfony\Component\Console\Input\StringInput;
 
 /**
  * Defines application features from the specific context.
@@ -397,7 +398,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	 */
 	public function iExecuteArtisan($command)
 	{
-		Artisan::call($command);
+		Artisan::handle(new StringInput($command));
 	}
 
 	/**

--- a/tests/acceptance/sprint_snapshots.feature
+++ b/tests/acceptance/sprint_snapshots.feature
@@ -41,5 +41,10 @@ Feature: Sprint Snapshots
 
   Scenario: Migrate snapshots from maniphest.query to maniphest.search
     Given there is a snapshot in the maniphest.query format
-    When I execute artisan "snapshots:migrate"
+    When I execute artisan "snapshots:migrate --force -q"
     Then the snapshot should be in the maniphest.search format
+
+  Scenario: Migrate snapshots from maniphest.query to maniphest.search with batchSize 0
+    Given there is a snapshot in the maniphest.query format
+    When I execute artisan "snapshots:migrate --batchSize 0 --force -q"
+    Then the snapshot should still be in the maniphest.query format


### PR DESCRIPTION
Migration on Labs failed due to the number of snapshots there (~2300). Loading all the snapshots with `SprintSnapshot::all()` consumed to much memory and the script failed.

see https://phabricator.wikimedia.org/T128581

The script was refactored to read the snapshots in batches and migrate them one after the other. In the process additional command line options were added e.g. to set step size. Simple output gives feedback on the progress of the migration.