### PR TITLE
Adjust PHPCS rules

### DIFF
--- a/app/Console/Commands/MigrateSnapshots.php
+++ b/app/Console/Commands/MigrateSnapshots.php
@@ -19,7 +19,7 @@ class MigrateSnapshots extends Command {
 			$confirmation = $this->confirm(
 				'Do you really want to migrate ' . $snapshotCount . ' snapshots in batches of ' . $batchSize . '?'
 			);
-			if ( !$confirmation) {
+			if (!$confirmation) {
 				$this->line('Migration aborted.');
 				return;
 			}

--- a/app/Console/Commands/MigrateSnapshots.php
+++ b/app/Console/Commands/MigrateSnapshots.php
@@ -16,7 +16,9 @@ class MigrateSnapshots extends Command {
 		$batchSize = intval($this->input->getOption('batchSize'));
 
 		if (!$this->input->getOption('force')) {
-			$confirmation = $this->confirm('Do you really want to migrate ' . $snapshotCount . ' snapshots in batches of ' . $batchSize . '?');
+			$confirmation = $this->confirm(
+				'Do you really want to migrate ' . $snapshotCount . ' snapshots in batches of ' . $batchSize . '?'
+			);
 			if ( !$confirmation) {
 				$this->line('Migration aborted.');
 				return;

--- a/app/Console/Commands/MigrateSnapshots.php
+++ b/app/Console/Commands/MigrateSnapshots.php
@@ -15,11 +15,13 @@ class MigrateSnapshots extends Command {
 		$snapshotCount = SprintSnapshot::count();
 		$batchSize = intval($this->input->getOption('batchSize'));
 
-		if (!$this->input->getOption('force')) {
+		if (!$this->input->getOption('force'))
+		{
 			$confirmation = $this->confirm(
 				'Do you really want to migrate ' . $snapshotCount . ' snapshots in batches of ' . $batchSize . '?'
 			);
-			if (!$confirmation) {
+			if (!$confirmation)
+			{
 				$this->line('Migration aborted.');
 				return;
 			}
@@ -27,7 +29,8 @@ class MigrateSnapshots extends Command {
 
 		$this->line('Migration in progress:');
 		$i = 0;
-		while (count($snapshots = $this->getSnapshotsPart($batchSize, $batchSize * $i)) !== 0) {
+		while (count($snapshots = $this->getSnapshotsPart($batchSize, $batchSize * $i)) !== 0)
+		{
 			foreach ($snapshots as $snapshot)
 			{
 				$snapshotData = json_decode($snapshot->data, true);
@@ -46,7 +49,8 @@ class MigrateSnapshots extends Command {
 
 	private function getMigrationProgress( $batchSize, $iteration, $snapshotCount)
 	{
-		if ($batchSize * $iteration >= $snapshotCount) {
+		if ($batchSize * $iteration >= $snapshotCount)
+		{
 			return 100;
 		}
 		return round($batchSize / $snapshotCount * $iteration, 2) * 100;

--- a/app/Console/Commands/lib/SnapshotDataConverter.php
+++ b/app/Console/Commands/lib/SnapshotDataConverter.php
@@ -17,7 +17,9 @@ class SnapshotDataConverter {
 
 	private function convertToManiphestSearchResponse(array $task)
 	{
-		$points = isset($task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')]) ? $task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')] : 0;
+		$points = isset(
+			$task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')]
+		) ? $task['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')] : 0;
 		return [
 			'id' => (int)$task['id'],
 			'type' => 'TASK',

--- a/app/Http/Controllers/SprintSnapshotsController.php
+++ b/app/Http/Controllers/SprintSnapshotsController.php
@@ -33,11 +33,11 @@ class SprintSnapshotsController extends Controller {
 
 		if ($snapshot->exists)
 		{
-			Flash::success("Successfully created a snapshot for \"$sprint->title\"");
+			Flash::success('Successfully created a snapshot for "' . $sprint->title . '"');
 			return Redirect::route('snapshot_path', $snapshot->id);
 		} else
 		{
-			Flash::error("The snapshot could not be created. Please try again");
+			Flash::error('The snapshot could not be created. Please try again');
 			return Redirect::route('sprint_live_path', $sprint->phabricator_id);
 		}
 	}

--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -70,7 +70,10 @@ class Sprint extends Eloquent {
 
 	private function getDays()
 	{
-		if ($this->days === null) $this->days = $this->computeDays();
+		if ($this->days === null)
+		{
+			$this->days = $this->computeDays();
+		}
 
 		return $this->days;
 	}

--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -93,7 +93,7 @@ class Sprint extends Eloquent {
 		$endTime = strtotime($this->sprint_end);
 		for ($day = $startTime;
 			 $day <= $endTime;
-			 $day += 60*60*24)
+			 $day += 60 * 60 * 24)
 		{
 			$days[] = $day;
 		}

--- a/app/Models/SprintSnapshot.php
+++ b/app/Models/SprintSnapshot.php
@@ -1,7 +1,7 @@
 <?php
 
 class SprintSnapshot extends Eloquent {
-	protected $fillable =  ['data', 'sprint_id', 'created_at', 'total_points', 'task_count'];
+	protected $fillable = ['data', 'sprint_id', 'created_at', 'total_points', 'task_count'];
 
 	/**
 	 * @return Sprint

--- a/app/Models/SprintSnapshot.php
+++ b/app/Models/SprintSnapshot.php
@@ -25,7 +25,8 @@ class SprintSnapshot extends Eloquent {
 
 	public function getData()
 	{
-		if ($this->data === null) {
+		if ($this->data === null)
+		{
 			$this->data = self::find($this->id)->data;
 		}
 

--- a/app/Phragile/ActionHandler/SprintStoreActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintStoreActionHandler.php
@@ -37,7 +37,10 @@ class SprintStoreActionHandler {
 
 	private function validate()
 	{
-		if ($this->previousActionFailed()) return;
+		if ($this->previousActionFailed())
+		{
+			return;
+		}
 
 		$validation = $this->sprint->validate();
 		if ($validation->fails())
@@ -49,7 +52,10 @@ class SprintStoreActionHandler {
 
 	private function trySprintCreationFromPhabricatorID()
 	{
-		if ($this->previousActionFailed() || !ctype_digit($this->sprint->title)) return;
+		if ($this->previousActionFailed() || !ctype_digit($this->sprint->title))
+		{
+			return;
+		}
 
 		if ($this->sprintWithPhabricatorIDExists())
 		{
@@ -75,7 +81,10 @@ class SprintStoreActionHandler {
 
 	private function connectUserToPhabricator()
 	{
-		if ($this->previousActionFailed()) return;
+		if ($this->previousActionFailed())
+		{
+			return;
+		}
 
 		if ($this->user->apiTokenValid())
 		{
@@ -88,7 +97,10 @@ class SprintStoreActionHandler {
 
 	private function createCorrespondingPhabricatorProject()
 	{
-		if ($this->previousActionFailed()) return;
+		if ($this->previousActionFailed())
+		{
+			return;
+		}
 
 		try
 		{
@@ -105,7 +117,10 @@ class SprintStoreActionHandler {
 		if (str_contains($errorMessage, ['Project name is already used', 'Project name generates the same hashtag']))
 		{
 			$this->connectWithPhabricatorProject();
-		} else $this->redirectBackWithError('Could not create a Phabricator project for this sprint.');
+		} else
+		{
+			$this->redirectBackWithError('Could not create a Phabricator project for this sprint.');
+		}
 	}
 
 	private function connectWithPhabricatorProject()
@@ -129,7 +144,10 @@ class SprintStoreActionHandler {
 
 	private function save($successMsg, $errorMsg)
 	{
-		if ($this->previousActionFailed()) return;
+		if ($this->previousActionFailed())
+		{
+			return;
+		}
 
 		if ($this->sprint->save())
 		{

--- a/app/Phragile/ActionHandler/SprintStoreActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintStoreActionHandler.php
@@ -106,7 +106,7 @@ class SprintStoreActionHandler {
 		{
 			$phabricatorProject = $this->userPhabricatorAPI->createProject($this->sprint->title, [$this->user->phid]);
 			$this->sprint->connectWithPhabricatorProject($phabricatorProject);
-		} catch(\ConduitClientException $e)
+		} catch (\ConduitClientException $e)
 		{
 			$this->connectIfPhabricatorProjectExists($e->getMessage());
 		}

--- a/app/Phragile/BurndownChart.php
+++ b/app/Phragile/BurndownChart.php
@@ -15,7 +15,9 @@ class BurndownChart {
 	 * @param array $transactions - an associative array that maps an array of transactions to task IDs
 	 * @param ClosedTimeDispatcher $closedTimeDispatcher - an associative array that maps an array of transactions to task IDs
 	 */
-	public function __construct(\Sprint $sprint, TaskList $tasks, array $transactions, ClosedTimeDispatcher $closedTimeDispatcher)
+	public function __construct(
+		\Sprint $sprint, TaskList $tasks, array $transactions, ClosedTimeDispatcher $closedTimeDispatcher
+	)
 	{
 		$this->sprint = $sprint;
 		$this->tasks = $tasks;

--- a/app/Phragile/ClosedTimeByStatusFieldDispatcher.php
+++ b/app/Phragile/ClosedTimeByStatusFieldDispatcher.php
@@ -7,7 +7,8 @@ class ClosedTimeByStatusFieldDispatcher implements ClosedTimeDispatcher {
 
 	public function isClosingTransaction(array $transaction)
 	{
-		if ($transaction['transactionType'] === 'status') {
+		if ($transaction['transactionType'] === 'status')
+		{
 			return in_array($transaction['oldValue'], self::$STATUS_OPEN) &&
 			       !in_array($transaction['newValue'], self::$STATUS_OPEN);
 		}

--- a/app/Phragile/ProjectColumnRepository.php
+++ b/app/Phragile/ProjectColumnRepository.php
@@ -28,7 +28,10 @@ class ProjectColumnRepository {
 		$this->initialize();
 		foreach ($this->projectColumns as $phid => $column)
 		{
-			if ($column['name'] === $name) return $phid;
+			if ($column['name'] === $name)
+			{
+				return $phid;
+			}
 		}
 		return null;
 	}

--- a/app/Phragile/ScopeLine.php
+++ b/app/Phragile/ScopeLine.php
@@ -47,7 +47,10 @@ class ScopeLine {
 	{
 		foreach ($this->dateRange as $date)
 		{
-			if (isset($this->snapshots[$date])) return $this->snapshots[$date]->getScope();
+			if (isset($this->snapshots[$date]))
+			{
+				return $this->snapshots[$date]->getScope();
+			}
 		}
 
 		return $this->pointsNumber;

--- a/app/Phragile/StatusByStatusFieldDispatcher.php
+++ b/app/Phragile/StatusByStatusFieldDispatcher.php
@@ -21,9 +21,16 @@ class StatusByStatusFieldDispatcher implements StatusDispatcher {
 
 	public function getStatus(array $task)
 	{
-		if ($this->isTaskInReview($task)) return 'patch to review';
-		elseif ($this->isTaskBeingDone($task)) return 'doing';
-		else return $task['fields']['status']['value'];
+		if ($this->isTaskInReview($task))
+		{
+			return 'patch to review';
+		} elseif ($this->isTaskBeingDone($task))
+		{
+			return 'doing';
+		} else
+		{
+			return $task['fields']['status']['value'];
+		}
 	}
 
 	public function isClosed(array $task)

--- a/app/Phragile/Task.php
+++ b/app/Phragile/Task.php
@@ -22,7 +22,7 @@ class Task {
 		{
 			if (!array_key_exists($field, $attributes))
 			{
-				throw new \InvalidArgumentException("The $field field is missing.");
+				throw new \InvalidArgumentException('The ' . $field . ' field is missing.');
 			}
 
 			$this->$field = $attributes[$field];

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 		"laracasts/behat-laravel-extension": "@dev",
 		"backup-manager/laravel": "~1.1",
 		"squizlabs/php_codesniffer": "~2.1",
+		"pragmarx/laravelcs": "dev-master",
 		"phpmd/phpmd": "~2.1"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4e2496c0046525db153b2c34dff3e230",
-    "content-hash": "a77c522328b616227bfb2bd1b3961fe8",
+    "hash": "9970a9464a80fe365f167b7710218645",
+    "content-hash": "8266ca056681080b805d70e1dc43f482",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -3760,6 +3760,45 @@
             "time": "2015-10-02 06:51:40"
         },
         {
+            "name": "pragmarx/laravelcs",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antonioribeiro/laravelcs.git",
+                "reference": "9be66937b1dae089a11c42b63a70c6e1b40c5525"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antonioribeiro/laravelcs/zipball/9be66937b1dae089a11c42b63a70c6e1b40c5525",
+                "reference": "9be66937b1dae089a11c42b63a70c6e1b40c5525",
+                "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Antonio Carlos Ribeiro",
+                    "email": "acr@antoniocarlosribeiro.com",
+                    "role": "Creator"
+                }
+            ],
+            "description": "PHP_CodeSniffer custom Sniff for Laravel coding standard",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "code",
+                "laravel",
+                "sniffer",
+                "standards"
+            ],
+            "time": "2014-12-14 18:47:14"
+        },
+        {
             "name": "sebastian/comparator",
             "version": "1.2.0",
             "source": {
@@ -4535,7 +4574,8 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "behat/behat": 5,
-        "laracasts/behat-laravel-extension": 20
+        "laracasts/behat-laravel-extension": 20,
+        "pragmarx/laravelcs": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -61,7 +61,7 @@
     <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
         <severity>0</severity>
     </rule>
-    <!-- Laravel doesn't use namespaces bu default, ignoring for now. -->
+    <!-- Laravel doesn't use namespaces by default, ignoring for now. -->
     <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
         <severity>0</severity>
     </rule>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,8 +16,8 @@
     <rule ref="Generic.Files.LineEndings" />
     <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="lineLimit" value="150" />
-            <property name="absoluteLineLimit" value="150" />
+            <property name="lineLimit" value="125" />
+            <property name="absoluteLineLimit" value="125" />
         </properties>
     </rule>
     <rule ref="Generic.Files.OneClassPerFile" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -82,8 +82,11 @@
     <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing" />
 
-    <!-- https://github.com/squizlabs/PHP_CodeSniffer/issues/348 -->
-    <!--<rule ref="Squiz.WhiteSpace.OperatorSpacing" />-->
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true" />
+        </properties>
+    </rule>
 
     <rule ref="Squiz.WhiteSpace.ScopeClosingBrace" />
     <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -67,6 +67,7 @@
     </rule>
 
     <rule ref="PSR2.Classes.PropertyDeclaration" />
+    <rule ref="PSR2.ControlStructures.ControlStructureSpacing" />
     <rule ref="PSR2.ControlStructures.ElseIfDeclaration" />
     <rule ref="PSR2.Namespaces" />
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,9 +7,6 @@
     <rule ref="Generic.Classes" />
     <rule ref="Generic.CodeAnalysis" />
     <rule ref="Generic.ControlStructures" />
-    <rule ref="Generic.ControlStructures.InlineControlStructure.NotAllowed">
-        <severity>0</severity>
-    </rule>
 
     <rule ref="Generic.Files.ByteOrderMark" />
     <rule ref="Generic.Files.EndFileNewline" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -98,5 +98,7 @@
         <severity>0</severity>
     </rule>
 
+    <rule ref="vendor/pragmarx/laravelcs/Standards/Laravel/Sniffs/ControlStructures" />
+
     <rule ref="Zend.Files.ClosingTag" />
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,7 +3,7 @@
 	- https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
 	- https://github.com/squizlabs/PHP_CodeSniffer/tree/master/CodeSniffer/Standards
 -->
-<ruleset name="MediaWiki">
+<ruleset name="Phragile">
     <rule ref="Generic.Classes" />
     <rule ref="Generic.CodeAnalysis" />
     <rule ref="Generic.ControlStructures" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -78,6 +78,7 @@
     <rule ref="Squiz.Functions.FunctionDuplicateArgument" />
     <rule ref="Squiz.Functions.GlobalFunction" />
     <rule ref="Squiz.Scope" />
+    <rule ref="Squiz.Strings.DoubleQuoteUsage" />
     <rule ref="Squiz.WhiteSpace.CastSpacing" />
     <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing" />
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing" />

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -76,7 +76,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		try
 		{
 			$this->pressButton('Authorize Access');
-		} catch(Behat\Mink\Exception\ElementNotFoundException $e)
+		} catch (Behat\Mink\Exception\ElementNotFoundException $e)
 		{
 			// Absence of this button just means that the user has authorized Phragile before.
 			return;
@@ -361,7 +361,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		try
 		{
 			$this->aSprintExistsForTheProject($sprintTitle, $projectTitle);
-		} catch(Exception $e)
+		} catch (Exception $e)
 		{
 			if (!str_contains($e->getMessage(), 'Project name is already used'))
 			{

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -628,7 +628,9 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	public function theSnapshotShouldBeInTheManiphestSearchFormat()
 	{
 		$snapshotTaskTitle = '[Phragile] Migration script for old snapshots';
-		$taskProcessor = new TaskDataProcessor(new StatusByStatusFieldDispatcher(''), ['ignore_estimates' => false, 'ignored_columns' => []]);
+		$taskProcessor = new TaskDataProcessor(
+			new StatusByStatusFieldDispatcher(''), ['ignore_estimates' => false, 'ignored_columns' => []]
+		);
 		$tasks = $taskProcessor->process(json_decode($this->testSnapshot->fresh()->getData(), true)['tasks']);
 		PHPUnit::assertSame($snapshotTaskTitle, $tasks[0]->getTitle());
 		PHPUnit::assertSame(12, $tasks[0]->getPoints());
@@ -663,7 +665,8 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 				"priority":"High",
 				"priorityColor":"red",
 				"title":"' . $this->testSnapshotTitle . '",
-				"description":"Snapshot data needs to be migrated to a new format since we are going to abandon maniphest.query in favor of maniphest.search.",
+				"description":"Snapshot data needs to be migrated to a new format since we are going to '
+		. 'abandon maniphest.query in favor of maniphest.search.",
 				"projectPHIDs":["PHID-PROJ-ptnfbfyq36kkebaxugcz","PHID-PROJ-tazsyaydzpbd643tderv","PHID-PROJ-knyj2bgnrkrwu72n27bg"],
 				"uri":"https:\/\/phabricator.wikimedia.org\/T127180",
 				"auxiliary":{

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -150,7 +150,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	{
 		if (!App::make('phabricator')->queryProjectByTitle($title))
 		{
-			throw new Exception("Project '$title' does not exist.");
+			throw new Exception('Project "' . $title . '" does not exist.');
 		}
 	}
 
@@ -348,7 +348,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	public function iAmOnTheProjectPage($project)
 	{
 		$this->theProjectExists($project);
-		$this->visit("/projects/" . Project::where('title', $project)->first()->slug);
+		$this->visit('/projects/' . Project::where('title', $project)->first()->slug);
 	}
 
 	/**
@@ -573,7 +573,7 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 	 */
 	public function iGoToTheSprintOverviewOfTheMissingSprint()
 	{
-		$this->visit("/sprints/$this->phabricatorProjectID");
+		$this->visit('/sprints/' . $this->phabricatorProjectID);
 	}
 
 	/**

--- a/tests/acceptance/bootstrap/FeatureContext.php
+++ b/tests/acceptance/bootstrap/FeatureContext.php
@@ -363,7 +363,10 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 			$this->aSprintExistsForTheProject($sprintTitle, $projectTitle);
 		} catch(Exception $e)
 		{
-			if (!str_contains($e->getMessage(), 'Project name is already used')) throw $e;
+			if (!str_contains($e->getMessage(), 'Project name is already used'))
+			{
+				throw $e;
+			}
 		}
 
 		Sprint::where('title', $sprintTitle)->where('project_id', $project->id)->delete();
@@ -485,7 +488,10 @@ class FeatureContext extends MinkContext implements Context, SnippetAcceptingCon
 		$phabricator = App::make('phabricator');
 		$tasks = (new TaskDataFetcher($phabricator))->fetchProjectTasks($sprintPHID);
 
-		if (!empty($tasks)) return array_values($tasks)[0];
+		if (!empty($tasks))
+		{
+			return array_values($tasks)[0];
+		}
 
 		return $phabricator->createTask($sprintPHID, [
 			'title' => 'automated test task',

--- a/tests/unit/BurndownChartTest.php
+++ b/tests/unit/BurndownChartTest.php
@@ -13,7 +13,9 @@ class BurndownChartTest extends TestCase {
 		return $this->mockWithTransactionsAndClosedTimeDispatcher($tasks, $transactions, new ClosedTimeByStatusFieldDispatcher());
 	}
 
-	private function mockWithTransactionsAndClosedTimeDispatcher(array $tasks, array $transactions, ClosedTimeDispatcher $dispatcher)
+	private function mockWithTransactionsAndClosedTimeDispatcher(
+		array $tasks, array $transactions, ClosedTimeDispatcher $dispatcher
+	)
 	{
 		$taskListMock = $this->getMockBuilder('Phragile\TaskList')
 			->disableOriginalConstructor()

--- a/tests/unit/PieChartTest.php
+++ b/tests/unit/PieChartTest.php
@@ -20,7 +20,7 @@ class PieChartTest extends TestCase {
 	{
 		$chart = new PieChart($tasksPerStatus, new StatusCssClassService(false));
 
-		foreach($chart->getData() as $data)
+		foreach ($chart->getData() as $data)
 		{
 			$this->assertArrayHasKey('cssClass', $data);
 		}

--- a/tests/unit/ScopeLineTest.php
+++ b/tests/unit/ScopeLineTest.php
@@ -20,7 +20,9 @@ class ScopeLineTest extends TestCase {
 		$scopeLine = new ScopeLine([], $numberOfPoints, $dateRange);
 
 		foreach ($scopeLine->getData() as $date => $points)
+		{
 			$this->assertSame($points, $numberOfPoints);
+		}
 	}
 
 	public function testShouldAlwaysUseLastSnapshot()

--- a/tests/unit/SnapshotDataConverterTest.php
+++ b/tests/unit/SnapshotDataConverterTest.php
@@ -5,7 +5,7 @@ class SnapshotDataConverterTest extends TestCase {
 	public function testGivenManiphestQueryData_ReturnsManiphestSearchData()
 	{
 		$customField = 'WMDE:storypoints';
-		$this->queryTaskData['0']['auxiliary']["std:maniphest:$customField"] = 'foo';
+		$this->queryTaskData['0']['auxiliary']['std:maniphest:' . $customField] = 'foo';
 		$this->queryTaskData['0']['auxiliary'][env('MANIPHEST_STORY_POINTS_FIELD')] = '5';
 		$convertedData = (new SnapshotDataConverter($this->queryTaskData))->convert();
 
@@ -17,7 +17,7 @@ class SnapshotDataConverterTest extends TestCase {
 		$this->assertSame($this->searchTaskData[0]['fields']['status']['value'], $convertedData[0]['fields']['status']['value']);
 		$this->assertSame($this->searchTaskData[0]['fields']['priority']['name'], $convertedData[0]['fields']['priority']['name']);
 		$this->assertSame($this->searchTaskData[0]['fields']['points'], $convertedData[0]['fields']['points']);
-		$this->assertSame('foo', $convertedData[0]['fields']["custom.$customField"]);
+		$this->assertSame('foo', $convertedData[0]['fields']['custom.' . $customField]);
 		$this->assertSame($this->queryTaskData['0']['projectPHIDs'], $convertedData[0]['attachments']['projects']['projectPHIDs']);
 	}
 

--- a/tests/unit/SnapshotDataConverterTest.php
+++ b/tests/unit/SnapshotDataConverterTest.php
@@ -38,7 +38,8 @@ class SnapshotDataConverterTest extends TestCase {
 			'priority' => 'High',
 			'priorityColor' => 'red',
 			'title' => '[Phragile] Migration script for old snapshots',
-			'description' => 'Snapshot data needs to be migrated to a new format since we are going to abandon maniphest.query in favor of maniphest.search.',
+			'description' => 'Snapshot data needs to be migrated to a new format since we are going to
+				abandon maniphest.query in favor of maniphest.search.',
 			'projectPHIDs' => [
 				'PHID-PROJ-ptnfbfyq36kkebaxugcz',
 				'PHID-PROJ-tazsyaydzpbd643tderv',


### PR DESCRIPTION
Following up https://github.com/wmde/phragile/pull/222 some more PHPCS adjustments to make code reviews easier.
I don't think it would be valid to say that we're aiming to stick to Laravel Code Style as they have changed their guidelines to be more PSR-2-alike. Any way rules added here are intended to make code follow the code style that Phragile uses from its beginning. Let's have the Phragile Code Style!

I've re-enabled sniff complaining about evil in-line control structures, and decreased a line length limit to 125 as used in many other WMDE repos.
https://github.com/wmde/phragile/commit/dfd01937cb104e302e45b20c5413bdc9cdaeddac takes care of not allowing `if ( sth )`.
https://github.com/wmde/phragile/commit/3acb64eca27d1ea20d0f6a3976e914366fab3dd1 is for things like
```php
foreach ($foo)
{
foo()
}
```
and
```php
if ($cat === 'nyan')
{
foo();
} else
{
bar();
}
```

Still there are some things that are missing, especially PHPCS wouldn't complain when function calls are written in the MW-alike spacey way e.g. `foo( 'bar', 'baz', 666 )` instead of preferred `foo('bar', 'baz', 666)`. I'd also like to have PHPCS enforce spaces around concatenation operator but it is missing at the moment. I'd try to add checks for those later.