### PR TITLE
Remove outdated credits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sprint overviews for your Phabricator projects!
 ## About
 With Phragile you can log in using your Phabricator account to create sprints for your projects on Phabricator. Phragile will then automatically generate burndown charts, pie charts and a sortable and filterable sprint backlog for you.
 
-Built by [Jakob Warkotsch](https://github.com/jakobw) as a thesis project at [Freie Universität Berlin](http://fu-berlin.de) in cooperation with [Wikimedia Deutschland](http://wikimedia.de).
+Built with ♥ in Berlin by [Wikimedia Deutschland](http://wikimedia.de).
 
 ## Issue Tracker
 If you find a bug or want to propose a new feature please report it on [Phabricator](https://phabricator.wikimedia.org/maniphest/task/create/?projects=phragile).

--- a/resources/views/project/index.blade.php
+++ b/resources/views/project/index.blade.php
@@ -32,7 +32,7 @@
 	<footer class="container">
 		<hr/>
 		<p>
-			Built by <a href="http://github.com/jakobw">Jakob Warkotsch</a> as a thesis project at <a href="http://fu-berlin.de">Freie Universität Berlin</a> in cooperation with <a href="http://wikimedia.de">Wikimedia Deutschland</a>.
+			Built with &hearts; in Berlin by <a href="http://wikimedia.de">Wikimedia Deutschland</a>.
 		</p>
 	</footer>
 @stop


### PR DESCRIPTION
I think this can now be removed since the entire TCB team has been working on it for almost a year and there's no need to impress my professor anymore :D
We could add a "Built at Wikimedia Deutschland" or something there though. Thoughts?