### PR TITLE
Use simplified transaction data structure internally and in snapshots

### DIFF
--- a/app/Http/Controllers/SprintSnapshotsController.php
+++ b/app/Http/Controllers/SprintSnapshotsController.php
@@ -1,5 +1,6 @@
 <?php
 
+use Phragile\TransactionSnapshotDataProcessor;
 use Phragile\Factory\SprintDataFactory;
 
 class SprintSnapshotsController extends Controller {
@@ -58,11 +59,13 @@ class SprintSnapshotsController extends Controller {
 	private function getSprintDataFactory(SprintSnapshot $snapshot)
 	{
 		$sprintData = json_decode($snapshot->getData(), true);
+		$processor = new TransactionSnapshotDataProcessor();
 		return new SprintDataFactory(
 			$snapshot->sprint,
 			$sprintData['tasks'],
-			$sprintData['transactions'],
+			$processor->process($sprintData['transactions']),
 			App::make('phabricator')
 		);
 	}
+
 }

--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -4,6 +4,8 @@ use Phragile\ProjectColumnRepository;
 use Phragile\TaskDataFetcher;
 use Phragile\TaskDataProcessor;
 use Phragile\TaskList;
+use Phragile\Transaction;
+use Phragile\TransactionRawDataProcessor;
 use Phragile\TransactionLoader;
 use Phragile\TransactionFilter;
 use Phragile\PhabricatorAPI;
@@ -101,6 +103,7 @@ class Sprint extends Eloquent {
 		return $days;
 	}
 
+	// TODO: consider moving createSnapshot to separate class?
 	/**
 	 * @return SprintSnapshot
 	 */
@@ -108,13 +111,20 @@ class Sprint extends Eloquent {
 	{
 		$phabricator = App::make('phabricator');
 		$rawTaskData = $this->fetchTasks($phabricator);
-		$data = $this->fetchSnapshotData($phabricator, $rawTaskData);
-		$columns = new ProjectColumnRepository($this->phid, $data['transactions'], $phabricator);
+		$rawTransactionData = $this->fetchTransactionData($phabricator, $rawTaskData);
+		$transactionDataProcessor = new TransactionRawDataProcessor();
+		$transactions = $transactionDataProcessor->process($rawTransactionData);
+		$columns = new ProjectColumnRepository($this->phid, $transactions, $phabricator);
 		$tasks = (new TaskDataProcessor(
-			(new StatusDispatcherFactory($this, $columns, $data['transactions']))->getStatusDispatcher(),
+			(new StatusDispatcherFactory($this, $columns, $transactions))->getStatusDispatcher(),
 			['ignore_estimates' => $this->ignore_estimates, 'ignored_columns' => $this->project->getIgnoredColumns()]
 		))->process($rawTaskData);
 		$sumOfTasks = (new TaskList($tasks))->getTasksPerStatus();
+
+		$data = [
+			'tasks' => $rawTaskData, // TODO: why not be bold and also store only converted task data here?
+			'transactions' => $this->getSnapshotTransactionData($transactions)
+		];
 
 		return SprintSnapshot::create([
 			'sprint_id' => $this->id,
@@ -129,21 +139,29 @@ class Sprint extends Eloquent {
 		return (new TaskDataFetcher($phabricator))->fetchProjectTasks($this->phid);
 	}
 
-	private function fetchSnapshotData(PhabricatorAPI $phabricator, array $tasks)
+	private function fetchTransactionData(PhabricatorAPI $phabricator, array $tasks)
 	{
 		$taskIDs = array_map(function($task)
 		{
 			return $task['id'];
 		}, $tasks);
-		$transactions = (new TransactionLoader(
+		return (new TransactionLoader(
 			new TransactionFilter(),
 			$phabricator
 		))->load($taskIDs);
+	}
 
-		return [
-			'tasks' => $tasks,
-			'transactions' => $transactions,
-		];
+	private function getSnapshotTransactionData(array $transactions)
+	{
+		$snapshotData = [];
+		foreach ($transactions as $taskID => $taskTransactions)
+		{
+			$snapshotData[$taskID] = array_map(function(Transaction $transaction)
+			{
+				return $transaction->getTransactionData();
+			}, $taskTransactions);
+		}
+		return $snapshotData;
 	}
 
 	/**

--- a/app/Phragile/ActionHandler/SprintLiveDataActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintLiveDataActionHandler.php
@@ -5,6 +5,7 @@ namespace Phragile\ActionHandler;
 use Phragile\PhabricatorAPI;
 use Phragile\SettingsAwareTransactionFilter;
 use Phragile\TaskDataFetcher;
+use Phragile\TransactionRawDataProcessor;
 use Phragile\TransactionLoader;
 use Sprint;
 use Phragile\Factory\SprintDataFactory;
@@ -45,6 +46,7 @@ class SprintLiveDataActionHandler {
 		{
 			return $task['id'];
 		}, $tasks);
+		$transactionDataProcessor = new TransactionRawDataProcessor();
 		$transactionLoader = new TransactionLoader(
 			new SettingsAwareTransactionFilter($sprint->project->workboard_mode),
 			$this->phabricatorAPI
@@ -53,7 +55,7 @@ class SprintLiveDataActionHandler {
 		return new SprintDataFactory(
 			$sprint,
 			$tasks,
-			$transactionLoader->load($taskIDs),
+			$transactionDataProcessor->process($transactionLoader->load($taskIDs)),
 			$this->phabricatorAPI
 		);
 	}

--- a/app/Phragile/BurndownChart.php
+++ b/app/Phragile/BurndownChart.php
@@ -12,7 +12,7 @@ class BurndownChart {
 	/**
 	 * @param \Sprint $sprint
 	 * @param TaskList $tasks
-	 * @param array $transactions - an associative array that maps an array of transactions to task IDs
+	 * @param Transaction[] $transactions - an associative array that maps an array of transactions to task IDs
 	 * @param ClosedTimeDispatcher $closedTimeDispatcher - an associative array that maps an array of transactions to task IDs
 	 */
 	public function __construct(
@@ -57,11 +57,12 @@ class BurndownChart {
 	{
 		return array_reduce(
 			$transactions,
-			function($time, $transaction)
+			function($time, Transaction $transaction)
 			{
 				if ($this->closedTimeDispatcher->isClosingTransaction($transaction))
 				{
-					return $transaction['dateCreated'];
+					//return $transaction['dateCreated'];
+					return $transaction->getTimestamp();
 				} else
 				{
 					return $time;

--- a/app/Phragile/ClosedTimeByStatusFieldDispatcher.php
+++ b/app/Phragile/ClosedTimeByStatusFieldDispatcher.php
@@ -5,14 +5,14 @@ class ClosedTimeByStatusFieldDispatcher implements ClosedTimeDispatcher {
 	// TODO: ideally these should come from a cached call to maniphest.querystatuses
 	private static $STATUS_OPEN = ['stalled', 'open'];
 
-	public function isClosingTransaction(array $transaction)
+	public function isClosingTransaction(Transaction $transaction)
 	{
-		if ($transaction['transactionType'] === 'status')
+		if ($transaction instanceof StatusChangeTransaction)
 		{
-			return in_array($transaction['oldValue'], self::$STATUS_OPEN) &&
-			       !in_array($transaction['newValue'], self::$STATUS_OPEN);
+			return in_array($transaction->getOldStatus(), self::$STATUS_OPEN) &&
+				!in_array($transaction->getNewStatus(), self::$STATUS_OPEN);
 		}
 
-		return $transaction['transactionType'] === 'mergedinto';
+		return $transaction instanceof MergedIntoTransaction;
 	}
 }

--- a/app/Phragile/ClosedTimeByWorkboardDispatcher.php
+++ b/app/Phragile/ClosedTimeByWorkboardDispatcher.php
@@ -11,12 +11,12 @@ class ClosedTimeByWorkboardDispatcher implements ClosedTimeDispatcher {
 		$this->closedColumnPHIDs = $closedColumnPHIDs;
 	}
 
-	public function isClosingTransaction(array $transaction)
+	public function isClosingTransaction(Transaction $transaction)
 	{
-		return $transaction['transactionType'] === 'core:columns'
-			&& $transaction['newValue'][0]['boardPHID'] === $this->phid
-			&& in_array($transaction['newValue'][0]['columnPHID'], $this->closedColumnPHIDs)
-			&& (empty($transaction['newValue'][0]['fromColumnPHIDs'])
-				|| !in_array(reset($transaction['newValue'][0]['fromColumnPHIDs']), $this->closedColumnPHIDs));
+		return $transaction instanceof ColumnChangeTransaction
+			&& $transaction->getWorkboardPHID() === $this->phid
+			&& in_array($transaction->getNewColumnPHID(), $this->closedColumnPHIDs)
+			&& ($transaction->getOldColumnPHID() === false
+				|| !in_array($transaction->getOldColumnPHID(), $this->closedColumnPHIDs));
 	}
 }

--- a/app/Phragile/ClosedTimeDispatcher.php
+++ b/app/Phragile/ClosedTimeDispatcher.php
@@ -2,5 +2,5 @@
 namespace Phragile;
 
 interface ClosedTimeDispatcher {
-	public function isClosingTransaction(array $transaction);
+	public function isClosingTransaction(Transaction $transaction);
 }

--- a/app/Phragile/ColumnChangeTransaction.php
+++ b/app/Phragile/ColumnChangeTransaction.php
@@ -4,6 +4,8 @@ namespace Phragile;
 
 class ColumnChangeTransaction extends Transaction {
 
+	const TYPE = 'columnChange';
+
 	/**
 	 * @var string
 	 */
@@ -60,8 +62,7 @@ class ColumnChangeTransaction extends Transaction {
 	public function getTransactionData()
 	{
 		return [
-			'type' => 'columnChange', // TODO: this string should be moved to some constant,
-			//                        //so it there is no need to type it in in other places. But constant of what? Transaction::sth?
+			'type' => self::TYPE,
 			'timestamp' => $this->timestamp,
 			'workboardPHID' => $this->workboardPHID,
 			'oldColumnPHID' => $this->oldColumnPHID,

--- a/app/Phragile/ColumnChangeTransaction.php
+++ b/app/Phragile/ColumnChangeTransaction.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Phragile;
+
+class ColumnChangeTransaction extends Transaction {
+
+	/**
+	 * @var string
+	 */
+	private $workboardPHID;
+
+	/**
+	 * @var string
+	 */
+	private $oldColumnPHID;
+
+	/**
+	 * @var string
+	 */
+	private $newColumnPHID;
+
+	// TODO: use array of values instead of n positional params?
+	/**
+	 * @param string $timestamp
+	 * @param string $workboardPHID
+	 * @param string|false $oldColumnPHID
+	 * @param string $newColumnPHID
+	 */
+	public function __construct($timestamp, $workboardPHID, $oldColumnPHID, $newColumnPHID)
+	{
+		$this->timestamp = $timestamp;
+		$this->workboardPHID = $workboardPHID;
+		$this->oldColumnPHID = $oldColumnPHID;
+		$this->newColumnPHID = $newColumnPHID;
+	}
+
+	public function getWorkboardPHID()
+	{
+		return $this->workboardPHID;
+	}
+
+	public function getOldColumnPHID()
+	{
+		return $this->oldColumnPHID;
+	}
+
+	public function getNewColumnPHID()
+	{
+		return $this->newColumnPHID;
+	}
+
+	public function getTransactionData()
+	{
+		return [
+			'type' => 'columnChange', // TODO: this string should be moved to some constant,
+			//                        //so it there is no need to type it in in other places. But constant of what? Transaction::sth?
+			'timestamp' => $this->timestamp,
+			'workboardPHID' => $this->workboardPHID,
+			'oldColumnPHID' => $this->oldColumnPHID,
+			'newColumnPHID' => $this->newColumnPHID,
+		];
+	}
+
+}

--- a/app/Phragile/ColumnChangeTransaction.php
+++ b/app/Phragile/ColumnChangeTransaction.php
@@ -19,19 +19,27 @@ class ColumnChangeTransaction extends Transaction {
 	 */
 	private $newColumnPHID;
 
-	// TODO: use array of values instead of n positional params?
 	/**
-	 * @param string $timestamp
-	 * @param string $workboardPHID
-	 * @param string|false $oldColumnPHID
-	 * @param string $newColumnPHID
+	 * @param array $attributes associative array with keys:
+	 *        - 'timestamp' string
+	 *        - 'workboardPHID' string
+	 *        - 'oldColumnPHID' string|false false means no old column (initial setting of the column)
+	 *        - 'newColumnPHID' string
 	 */
-	public function __construct($timestamp, $workboardPHID, $oldColumnPHID, $newColumnPHID)
+	public function __construct(array $attributes)
 	{
-		$this->timestamp = $timestamp;
-		$this->workboardPHID = $workboardPHID;
-		$this->oldColumnPHID = $oldColumnPHID;
-		$this->newColumnPHID = $newColumnPHID;
+		$fields = ['timestamp', 'workboardPHID', 'oldColumnPHID', 'newColumnPHID'];
+		foreach ($fields as $field)
+		{
+			if (!array_key_exists($field, $attributes))
+			{
+				throw new \InvalidArgumentException('The ' . $field . ' field is missing.');
+			}
+		}
+		$this->timestamp = $attributes['timestamp'];
+		$this->workboardPHID = $attributes['workboardPHID'];
+		$this->oldColumnPHID = $attributes['oldColumnPHID'];
+		$this->newColumnPHID = $attributes['newColumnPHID'];
 	}
 
 	public function getWorkboardPHID()

--- a/app/Phragile/Factory/SprintDataFactory.php
+++ b/app/Phragile/Factory/SprintDataFactory.php
@@ -17,6 +17,9 @@ use Phragile\Task;
 
 class SprintDataFactory {
 	private $sprint = null;
+	/**
+	 * @var Transaction[]
+	 */
 	private $transactions = [];
 	private $phabricatorAPI = null;
 

--- a/app/Phragile/Factory/StatusDispatcherFactory.php
+++ b/app/Phragile/Factory/StatusDispatcherFactory.php
@@ -11,6 +11,9 @@ class StatusDispatcherFactory
 {
 	private $sprint = null;
 	private $projectColumnRepository = null;
+	/**
+	 * @var Transaction[]
+	 */
 	private $transactions = [];
 
 	public function __construct(\Sprint $sprint, ProjectColumnRepository $projectColumnRepository, array $transactions)

--- a/app/Phragile/MergedIntoTransaction.php
+++ b/app/Phragile/MergedIntoTransaction.php
@@ -4,6 +4,8 @@ namespace Phragile;
 
 class MergedIntoTransaction extends Transaction {
 
+	const TYPE = 'mergedInto';
+
 	public function __construct($timestamp)
 	{
 		$this->timestamp = $timestamp;
@@ -12,7 +14,7 @@ class MergedIntoTransaction extends Transaction {
 	public function getTransactionData()
 	{
 		return [
-			'type' => 'mergedInto', // TODO: same thing as in ColumnChangeTransaction::getTransactionData
+			'type' => self::TYPE,
 			'timestamp' => $this->timestamp,
 		];
 	}

--- a/app/Phragile/MergedIntoTransaction.php
+++ b/app/Phragile/MergedIntoTransaction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Phragile;
+
+class MergedIntoTransaction extends Transaction {
+
+	public function __construct($timestamp)
+	{
+		$this->timestamp = $timestamp;
+	}
+
+	public function getTransactionData()
+	{
+		return [
+			'type' => 'mergedInto', // TODO: same thing as in ColumnChangeTransaction::getTransactionData
+			'timestamp' => $this->timestamp,
+		];
+	}
+
+}

--- a/app/Phragile/ProjectColumnRepository.php
+++ b/app/Phragile/ProjectColumnRepository.php
@@ -6,6 +6,9 @@ class ProjectColumnRepository {
 	 * @var array|null maps workboard column PHIDs to a map of column data
 	 */
 	private $projectColumns = null;
+	/**
+	 * @var Transaction[]
+	 */
 	private $transactions;
 	private $phabricator;
 	private $projectPHID;
@@ -58,12 +61,12 @@ class ProjectColumnRepository {
 
 	private function findColumnPHIDs($columns, $transactions)
 	{
-		return array_reduce($transactions, function($columns, $transaction)
+		return array_reduce($transactions, function($columns, Transaction $transaction)
 		{
-			if ($transaction['transactionType'] === 'core:columns' && $transaction['newValue'][0]['boardPHID'] === $this->projectPHID)
+			if ($transaction instanceof ColumnChangeTransaction && $transaction->getWorkboardPHID() === $this->projectPHID)
 			{
-				$columns[] = $transaction['newValue'][0]['columnPHID'];
-				$columns[] = reset($transaction['newValue'][0]['fromColumnPHIDs']);
+				$columns[] = $transaction->getNewColumnPHID();
+				$columns[] = $transaction->getOldColumnPHID();
 			}
 
 			return $columns;

--- a/app/Phragile/SortedTransactionList.php
+++ b/app/Phragile/SortedTransactionList.php
@@ -3,8 +3,14 @@
 namespace Phragile;
 
 class SortedTransactionList {
+	/**
+	 * @var Transaction[]
+	 */
 	private $transactions = [];
 
+	/**
+	 * @param Transaction[] $transactions
+	 */
 	public function __construct(array $transactions)
 	{
 		$this->transactions = $this->sortTaskTransactions($transactions);
@@ -27,9 +33,9 @@ class SortedTransactionList {
 
 	private function sortChronologically(array $transactions)
 	{
-		usort($transactions, function($t1, $t2)
+		usort($transactions, function(Transaction $t1, Transaction $t2)
 		{
-			return ($t1['dateCreated'] < $t2['dateCreated']) ? -1 : 1;
+			return $t1->getTimestamp() < $t2->getTimestamp() ? -1 : 1;
 		});
 
 		return $transactions;

--- a/app/Phragile/StatusByWorkboardDispatcher.php
+++ b/app/Phragile/StatusByWorkboardDispatcher.php
@@ -2,6 +2,7 @@
 namespace Phragile;
 
 class StatusByWorkboardDispatcher implements StatusDispatcher {
+	// TODO: $transactions field not needed?
 	private $transactions = [];
 	private $columns = null;
 	private $sprint = null;
@@ -32,11 +33,11 @@ class StatusByWorkboardDispatcher implements StatusDispatcher {
 
 	private function findCurrentColumn(array $taskTransactions)
 	{
-		return array_reduce($taskTransactions, function($column, $transaction)
+		return array_reduce($taskTransactions, function($column, Transaction $transaction)
 		{
-			return $transaction['transactionType'] === 'core:columns'
-				&& $transaction['newValue'][0]['boardPHID'] === $this->sprint->phid
-				? $transaction['newValue'][0]['columnPHID']
+			return $transaction instanceof ColumnChangeTransaction
+				&& $transaction->getWorkboardPHID() === $this->sprint->phid
+				? $transaction->getNewColumnPHID()
 				: $column;
 		});
 	}

--- a/app/Phragile/StatusChangeTransaction.php
+++ b/app/Phragile/StatusChangeTransaction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Phragile;
+
+class StatusChangeTransaction extends Transaction {
+
+	/**
+	 * @var string|null
+	 */
+	private $oldStatus;
+
+	/**
+	 * @var string TODO: or could this be also null?
+	 */
+	private $newStatus;
+
+	// TODO: consider switching to array of values instead of 2 (or more) params
+	// $trans = new StatusChangeTransaction(null, 'doing') is not really nice
+	public function __construct($timestamp, $oldStatus, $newStatus)
+	{
+		$this->timestamp = $timestamp;
+		$this->oldStatus = $oldStatus;
+		$this->newStatus = $newStatus;
+	}
+
+	public function getOldStatus()
+	{
+		return $this->oldStatus;
+	}
+
+	public function getNewStatus()
+	{
+		return $this->newStatus;
+	}
+
+	public function getTransactionData()
+	{
+		return [
+			'type' => 'statusChange', // TODO: same thing as in ColumnChangeTransaction::getTransactionData
+			'timestamp' => $this->timestamp,
+			'oldStatus' => $this->oldStatus,
+			'newStatus' => $this->newStatus,
+		];
+	}
+}

--- a/app/Phragile/StatusChangeTransaction.php
+++ b/app/Phragile/StatusChangeTransaction.php
@@ -14,13 +14,25 @@ class StatusChangeTransaction extends Transaction {
 	 */
 	private $newStatus;
 
-	// TODO: consider switching to array of values instead of 2 (or more) params
-	// $trans = new StatusChangeTransaction(null, 'doing') is not really nice
-	public function __construct($timestamp, $oldStatus, $newStatus)
+	/**
+	 * @param array $attributes associative array with keys:
+	 *        - 'timestamp' string
+	 *        - 'oldStatus' string|null null means no old status (initial setting of the status)
+	 *        - 'newStatus' string
+	 */
+	public function __construct(array $attributes)
 	{
-		$this->timestamp = $timestamp;
-		$this->oldStatus = $oldStatus;
-		$this->newStatus = $newStatus;
+		$fields = ['timestamp', 'oldStatus', 'newStatus'];
+		foreach ($fields as $field)
+		{
+			if (!array_key_exists($field, $attributes))
+			{
+				throw new \InvalidArgumentException('The ' . $field . ' field is missing.');
+			}
+		}
+		$this->timestamp = $attributes['timestamp'];
+		$this->oldStatus = $attributes['oldStatus'];
+		$this->newStatus = $attributes['newStatus'];
 	}
 
 	public function getOldStatus()

--- a/app/Phragile/StatusChangeTransaction.php
+++ b/app/Phragile/StatusChangeTransaction.php
@@ -4,6 +4,8 @@ namespace Phragile;
 
 class StatusChangeTransaction extends Transaction {
 
+	const TYPE = 'statusChange';
+
 	/**
 	 * @var string|null
 	 */
@@ -48,7 +50,7 @@ class StatusChangeTransaction extends Transaction {
 	public function getTransactionData()
 	{
 		return [
-			'type' => 'statusChange', // TODO: same thing as in ColumnChangeTransaction::getTransactionData
+			'type' => self::TYPE,
 			'timestamp' => $this->timestamp,
 			'oldStatus' => $this->oldStatus,
 			'newStatus' => $this->newStatus,

--- a/app/Phragile/StatusChangeTransaction.php
+++ b/app/Phragile/StatusChangeTransaction.php
@@ -10,7 +10,7 @@ class StatusChangeTransaction extends Transaction {
 	private $oldStatus;
 
 	/**
-	 * @var string TODO: or could this be also null?
+	 * @var string
 	 */
 	private $newStatus;
 

--- a/app/Phragile/Transaction.php
+++ b/app/Phragile/Transaction.php
@@ -4,6 +4,8 @@ namespace Phragile;
 
 abstract class Transaction {
 
+	const TYPE = 'undefined';
+
 	// TODO: consider renaming the field to something more meaningful
 	protected $timestamp;
 

--- a/app/Phragile/Transaction.php
+++ b/app/Phragile/Transaction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Phragile;
+
+abstract class Transaction {
+
+	// TODO: consider renaming the field to something more meaningful
+	protected $timestamp;
+
+	public function getTimestamp()
+	{
+		return $this->timestamp;
+	}
+
+	abstract public function getTransactionData();
+
+}

--- a/app/Phragile/Transaction.php
+++ b/app/Phragile/Transaction.php
@@ -12,6 +12,7 @@ abstract class Transaction {
 		return $this->timestamp;
 	}
 
+	// TODO: would getSnapshotData be a better name?
 	abstract public function getTransactionData();
 
 }

--- a/app/Phragile/TransactionFilter.php
+++ b/app/Phragile/TransactionFilter.php
@@ -24,12 +24,12 @@ class TransactionFilter {
 
 	protected function isWorkboardTransaction(array $transaction)
 	{
-		return $transaction['transactionType'] === 'core:columns';
+		return $transaction['transactionType'] === TransactionRawDataProcessor::COLUMN_CHANGE_TRANSACTION;
 	}
 
 	protected function isStatusTransaction(array $transaction)
 	{
-		return $transaction['transactionType'] === 'status'
-		    || $transaction['transactionType'] === 'mergedinto';
+		return $transaction['transactionType'] === TransactionRawDataProcessor::STATUS_CHANGE_TRANSACTION
+		    || $transaction['transactionType'] === TransactionRawDataProcessor::MERGED_INTO_TRANSACTION;
 	}
 }

--- a/app/Phragile/TransactionFilter.php
+++ b/app/Phragile/TransactionFilter.php
@@ -1,6 +1,7 @@
 <?php
 namespace Phragile;
 
+// TODO: rename to e.g. TransactionDataFilter
 class TransactionFilter {
 	/**
 	 * Filters out irrelevant transactions

--- a/app/Phragile/TransactionLoader.php
+++ b/app/Phragile/TransactionLoader.php
@@ -1,6 +1,7 @@
 <?php
 namespace Phragile;
 
+// TODO: rename to e.g. TransactionDataFetcher?
 class TransactionLoader {
 	private $transactionFilter;
 	private $phabricatorAPI;

--- a/app/Phragile/TransactionRawDataProcessor.php
+++ b/app/Phragile/TransactionRawDataProcessor.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Phragile;
+
+class TransactionRawDataProcessor {
+
+	public function process(array $rawData)
+	{
+		$transactions = [];
+		foreach ($rawData as $task => $taskTransactionData)
+		{
+			$transactions[$task] = $this->processTaskTransactionData($taskTransactionData);
+		}
+		return $transactions;
+	}
+
+	private function processTaskTransactionData(array $rawTaskTransactionData)
+	{
+		$transactions = [];
+		foreach ($rawTaskTransactionData as $singleTransactionData)
+		{
+			if ($this->isColumnChangeTransaction($singleTransactionData))
+			{
+				$transactions[] = new ColumnChangeTransaction(
+					$this->getTransactionTimestamp($singleTransactionData),
+					$this->getWorkboardPHID($singleTransactionData),
+					$this->getOldColumnPHID($singleTransactionData),
+					$this->getNewColumnPHID($singleTransactionData)
+				);
+			} elseif ($this->isStatusChangeTransaction($singleTransactionData))
+			{
+				$transactions[] = new StatusChangeTransaction(
+					$this->getTransactionTimestamp($singleTransactionData),
+					$this->getOldStatus($singleTransactionData),
+					$this->getNewStatus($singleTransactionData)
+				);
+			} elseif ($this->isMergedIntoTransaction($singleTransactionData))
+			{
+				$transactions[] = new MergedIntoTransaction(
+					$this->getTransactionTimestamp($singleTransactionData)
+				);
+			}
+		}
+		return $transactions;
+	}
+
+	private function isColumnChangeTransaction(array $rawData)
+	{
+		return array_key_exists('transactionType', $rawData)
+			&& $rawData['transactionType'] === 'core:columns';
+	}
+
+	private function isStatusChangeTransaction(array $rawData)
+	{
+		return array_key_exists('transactionType', $rawData)
+			&& $rawData['transactionType'] === 'status';
+	}
+
+	private function isMergedIntoTransaction(array $rawData)
+	{
+		return array_key_exists('transactionType', $rawData)
+		&& $rawData['transactionType'] === 'mergedinto';
+	}
+
+	private function getTransactionTimestamp(array $rawData)
+	{
+		return $rawData['dateCreated'];
+	}
+
+	private function getWorkboardPHID(array $rawData)
+	{
+		return $rawData['newValue'][0]['boardPHID'];
+	}
+
+	private function getOldColumnPHID(array $rawData)
+	{
+		return reset($rawData['newValue'][0]['fromColumnPHIDs']);
+	}
+
+	private function getNewColumnPHID(array $rawData)
+	{
+		return $rawData['newValue'][0]['columnPHID'];
+	}
+
+	private function getOldStatus(array $rawData)
+	{
+		return $rawData['oldValue'];
+	}
+
+	private function getNewStatus(array $rawData)
+	{
+		return $rawData['newValue'];
+	}
+
+}

--- a/app/Phragile/TransactionRawDataProcessor.php
+++ b/app/Phragile/TransactionRawDataProcessor.php
@@ -4,6 +4,10 @@ namespace Phragile;
 
 class TransactionRawDataProcessor {
 
+	const COLUMN_CHANGE_TRANSACTION = 'core:columns';
+	const STATUS_CHANGE_TRANSACTION = 'status';
+	const MERGED_INTO_TRANSACTION = 'mergedinto';
+
 	public function process(array $rawData)
 	{
 		$transactions = [];
@@ -47,19 +51,19 @@ class TransactionRawDataProcessor {
 	private function isColumnChangeTransaction(array $rawData)
 	{
 		return array_key_exists('transactionType', $rawData)
-			&& $rawData['transactionType'] === 'core:columns';
+			&& $rawData['transactionType'] === self::COLUMN_CHANGE_TRANSACTION;
 	}
 
 	private function isStatusChangeTransaction(array $rawData)
 	{
 		return array_key_exists('transactionType', $rawData)
-			&& $rawData['transactionType'] === 'status';
+			&& $rawData['transactionType'] === self::STATUS_CHANGE_TRANSACTION;
 	}
 
 	private function isMergedIntoTransaction(array $rawData)
 	{
 		return array_key_exists('transactionType', $rawData)
-		&& $rawData['transactionType'] === 'mergedinto';
+		&& $rawData['transactionType'] === self::MERGED_INTO_TRANSACTION;
 	}
 
 	private function getTransactionTimestamp(array $rawData)

--- a/app/Phragile/TransactionRawDataProcessor.php
+++ b/app/Phragile/TransactionRawDataProcessor.php
@@ -21,19 +21,19 @@ class TransactionRawDataProcessor {
 		{
 			if ($this->isColumnChangeTransaction($singleTransactionData))
 			{
-				$transactions[] = new ColumnChangeTransaction(
-					$this->getTransactionTimestamp($singleTransactionData),
-					$this->getWorkboardPHID($singleTransactionData),
-					$this->getOldColumnPHID($singleTransactionData),
-					$this->getNewColumnPHID($singleTransactionData)
-				);
+				$transactions[] = new ColumnChangeTransaction([
+					'timestamp' => $this->getTransactionTimestamp($singleTransactionData),
+					'workboardPHID' => $this->getWorkboardPHID($singleTransactionData),
+					'oldColumnPHID' => $this->getOldColumnPHID($singleTransactionData),
+					'newColumnPHID' => $this->getNewColumnPHID($singleTransactionData),
+				]);
 			} elseif ($this->isStatusChangeTransaction($singleTransactionData))
 			{
-				$transactions[] = new StatusChangeTransaction(
-					$this->getTransactionTimestamp($singleTransactionData),
-					$this->getOldStatus($singleTransactionData),
-					$this->getNewStatus($singleTransactionData)
-				);
+				$transactions[] = new StatusChangeTransaction([
+					'timestamp' => $this->getTransactionTimestamp($singleTransactionData),
+					'oldStatus' => $this->getOldStatus($singleTransactionData),
+					'newStatus' => $this->getNewStatus($singleTransactionData),
+				]);
 			} elseif ($this->isMergedIntoTransaction($singleTransactionData))
 			{
 				$transactions[] = new MergedIntoTransaction(

--- a/app/Phragile/TransactionSnapshotDataProcessor.php
+++ b/app/Phragile/TransactionSnapshotDataProcessor.php
@@ -26,19 +26,19 @@ class TransactionSnapshotDataProcessor {
 		}
 		if ($snapshotTransaction['type'] === 'columnChange')
 		{
-			return new ColumnChangeTransaction(
-				$snapshotTransaction['timestamp'],
-				$snapshotTransaction['workboardPHID'],
-				$snapshotTransaction['oldColumnPHID'],
-				$snapshotTransaction['newColumnPHID']
-			);
+			return new ColumnChangeTransaction([
+				'timestamp' => $snapshotTransaction['timestamp'],
+				'workboardPHID' => $snapshotTransaction['workboardPHID'],
+				'oldColumnPHID' => $snapshotTransaction['oldColumnPHID'],
+				'newColumnPHID' => $snapshotTransaction['newColumnPHID'],
+			]);
 		} elseif ($snapshotTransaction['type'] === 'statusChange')
 		{
-			return new StatusChangeTransaction(
-				$snapshotTransaction['timestamp'],
-				$snapshotTransaction['oldStatus'],
-				$snapshotTransaction['newStatus']
-			);
+			return new StatusChangeTransaction([
+				'timestamp' => $snapshotTransaction['timestamp'],
+				'oldStatus' => $snapshotTransaction['oldStatus'],
+				'newStatus' => $snapshotTransaction['newStatus']
+			]);
 		} elseif ($snapshotTransaction['type'] === 'mergedInto')
 		{
 			return new MergedIntoTransaction($snapshotTransaction['timestamp']);

--- a/app/Phragile/TransactionSnapshotDataProcessor.php
+++ b/app/Phragile/TransactionSnapshotDataProcessor.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Phragile;
+
+class TransactionSnapshotDataProcessor {
+
+	public function process(array $snapshotData)
+	{
+		$transactions = [];
+		foreach ($snapshotData as $taskID => $taskTransactions)
+		{
+			$transactions[$taskID] = array_filter(array_map([$this, 'getSnapshotTransaction'], $taskTransactions));
+		}
+		return $transactions;
+	}
+
+	/**
+	 * @param array $snapshotTransaction
+	 * @return Transaction|false
+	 */
+	private function getSnapshotTransaction(array $snapshotTransaction)
+	{
+		if (!array_key_exists('type', $snapshotTransaction))
+		{
+			return false;
+		}
+		if ($snapshotTransaction['type'] === 'columnChange')
+		{
+			return new ColumnChangeTransaction(
+				$snapshotTransaction['timestamp'],
+				$snapshotTransaction['workboardPHID'],
+				$snapshotTransaction['oldColumnPHID'],
+				$snapshotTransaction['newColumnPHID']
+			);
+		} elseif ($snapshotTransaction['type'] === 'statusChange')
+		{
+			return new StatusChangeTransaction(
+				$snapshotTransaction['timestamp'],
+				$snapshotTransaction['oldStatus'],
+				$snapshotTransaction['newStatus']
+			);
+		} elseif ($snapshotTransaction['type'] === 'mergedInto')
+		{
+			return new MergedIntoTransaction($snapshotTransaction['timestamp']);
+		}
+		return false;
+	}
+
+}

--- a/app/Phragile/TransactionSnapshotDataProcessor.php
+++ b/app/Phragile/TransactionSnapshotDataProcessor.php
@@ -24,7 +24,7 @@ class TransactionSnapshotDataProcessor {
 		{
 			return false;
 		}
-		if ($snapshotTransaction['type'] === 'columnChange')
+		if ($snapshotTransaction['type'] === ColumnChangeTransaction::TYPE)
 		{
 			return new ColumnChangeTransaction([
 				'timestamp' => $snapshotTransaction['timestamp'],
@@ -32,14 +32,14 @@ class TransactionSnapshotDataProcessor {
 				'oldColumnPHID' => $snapshotTransaction['oldColumnPHID'],
 				'newColumnPHID' => $snapshotTransaction['newColumnPHID'],
 			]);
-		} elseif ($snapshotTransaction['type'] === 'statusChange')
+		} elseif ($snapshotTransaction['type'] === StatusChangeTransaction::TYPE)
 		{
 			return new StatusChangeTransaction([
 				'timestamp' => $snapshotTransaction['timestamp'],
 				'oldStatus' => $snapshotTransaction['oldStatus'],
 				'newStatus' => $snapshotTransaction['newStatus']
 			]);
-		} elseif ($snapshotTransaction['type'] === 'mergedInto')
+		} elseif ($snapshotTransaction['type'] === MergedIntoTransaction::TYPE)
 		{
 			return new MergedIntoTransaction($snapshotTransaction['timestamp']);
 		}

--- a/tests/unit/BurndownChartTest.php
+++ b/tests/unit/BurndownChartTest.php
@@ -184,7 +184,7 @@ class BurndownChartTest extends TestCase {
 					'anyNotClosed',
 					$this->closedColumnPHIDs[1]
 				)],
-				'2' => [new \Phragile\ColumnChangeTransaction(
+				'2' => [new ColumnChangeTransaction(
 					'1418050000', // Dec 8
 					$this->testProjectPHID,
 					'anyNotClosed',

--- a/tests/unit/BurndownChartTest.php
+++ b/tests/unit/BurndownChartTest.php
@@ -85,18 +85,18 @@ class BurndownChartTest extends TestCase {
 			$this->tasks,
 			[
 				'1' => [
-					new StatusChangeTransaction(
-						'1418040000', // Dec 8
-						'open',
-						'resolved'
-					)
+					new StatusChangeTransaction([
+						'timestamp' => '1418040000', // Dec 8
+						'oldStatus' => 'open',
+						'newStatus' => 'resolved',
+					])
 				],
 				'2' => [
-					new StatusChangeTransaction(
-						'1418050000',
-						'open',
-						'resolved'
-					)
+					new StatusChangeTransaction([
+						'timestamp' => '1418050000',
+						'oldStatus' => 'open',
+						'newStatus' => 'resolved',
+					])
 				]
 			]
 		);
@@ -108,11 +108,11 @@ class BurndownChartTest extends TestCase {
 	{
 		$burndown = $this->mockWithTransactions(
 			$this->tasks,
-			['1' => [new StatusChangeTransaction(
-				'1415664000', // Nov 11
-				'open',
-				'resolved'
-			)]]
+			['1' => [new StatusChangeTransaction([
+				'timestamp' => '1415664000', // Nov 11
+				'oldStatus' => 'open',
+				'newStatus' => 'resolved',
+			])]]
 		);
 
 		$this->assertSame(8, $burndown->getPointsClosedBeforeSprint());
@@ -124,16 +124,16 @@ class BurndownChartTest extends TestCase {
 			['1' => $this->tasks['1']],
 			[
 				'1' => [
-					new StatusChangeTransaction(
-						'1418040000', // Dec 8
-						'open',
-						'resolved'
-					),
-					new StatusChangeTransaction(
-						'1418130000', // Dec 9
-						'resolved',
-						'invalid'
-					)
+					new StatusChangeTransaction([
+						'timestamp' => '1418040000', // Dec 8
+						'oldStatus' => 'open',
+						'newStatus' => 'resolved',
+					]),
+					new StatusChangeTransaction([
+						'timestamp' => '1418130000', // Dec 9
+						'oldStatus' => 'resolved',
+						'newStatus' => 'invalid',
+					])
 				]
 			]
 		);
@@ -149,21 +149,21 @@ class BurndownChartTest extends TestCase {
 			['1' => $this->tasks['1']],
 			[
 				'1' => [
-					new StatusChangeTransaction(
-						'1418040000', // Dec 8
-						'open',
-						'resolved'
-					),
-					new StatusChangeTransaction(
-						'1418050000',
-						'resolved',
-						'open'
-					),
-					new StatusChangeTransaction(
-						'1418130000', // Dec 9
-						'open',
-						'resolved'
-					)
+					new StatusChangeTransaction([
+						'timestamp' => '1418040000', // Dec 8
+						'oldStatus' => 'open',
+						'newStatus' => 'resolved',
+					]),
+					new StatusChangeTransaction([
+						'timestamp' => '1418050000',
+						'oldStatus' => 'resolved',
+						'newStatus' => 'open',
+					]),
+					new StatusChangeTransaction([
+						'timestamp' => '1418130000', // Dec 9
+						'oldStatus' => 'open',
+						'newStatus' => 'resolved',
+					])
 				]
 			]
 		);
@@ -178,18 +178,18 @@ class BurndownChartTest extends TestCase {
 		$burndown = $this->mockWithTransactionsInWorkboardMode(
 			$this->tasks,
 			[
-				'1' => [new ColumnChangeTransaction(
-					'1418040000', // Dec 8
-					$this->testProjectPHID,
-					'anyNotClosed',
-					$this->closedColumnPHIDs[1]
-				)],
-				'2' => [new ColumnChangeTransaction(
-					'1418050000', // Dec 8
-					$this->testProjectPHID,
-					'anyNotClosed',
-					$this->closedColumnPHIDs[0]
-				)]
+				'1' => [new ColumnChangeTransaction([
+					'timestamp' => '1418040000', // Dec 8
+					'workboardPHID' => $this->testProjectPHID,
+					'oldColumnPHID' => 'anyNotClosed',
+					'newColumnPHID' => $this->closedColumnPHIDs[1],
+				])],
+				'2' => [new ColumnChangeTransaction([
+					'timestamp' => '1418050000', // Dec 8
+					'workboardPHID' => $this->testProjectPHID,
+					'oldColumnPHID' => 'anyNotClosed',
+					'newColumnPHID' => $this->closedColumnPHIDs[0],
+				])]
 			]
 		);
 
@@ -202,24 +202,24 @@ class BurndownChartTest extends TestCase {
 			$this->tasks,
 			[
 				'1' => [
-					new ColumnChangeTransaction(
-						DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 10:00:00')->format('U'),
-						$this->testProjectPHID,
-						'anyNotClosed',
-						$this->closedColumnPHIDs[1]
-					),
-					new ColumnChangeTransaction(
-						DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 12:00:00')->format('U'),
-						$this->testProjectPHID,
-						$this->closedColumnPHIDs[1],
-						'anyNotClosed'
-					),
-					new ColumnChangeTransaction(
-						DateTime::createFromFormat('d.m.Y H:i:s', '09.12.2014 10:00:00')->format('U'),
-						$this->testProjectPHID,
-						'anyNotClosed',
-						$this->closedColumnPHIDs[1]
-					),
+					new ColumnChangeTransaction([
+						'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 10:00:00')->format('U'),
+						'workboardPHID' => $this->testProjectPHID,
+						'oldColumnPHID' => 'anyNotClosed',
+						'newColumnPHID' => $this->closedColumnPHIDs[1],
+					]),
+					new ColumnChangeTransaction([
+						'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 12:00:00')->format('U'),
+						'workboardPHID' => $this->testProjectPHID,
+						'oldColumnPHID' => $this->closedColumnPHIDs[1],
+						'newColumnPHID' => 'anyNotClosed',
+					]),
+					new ColumnChangeTransaction([
+						'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '09.12.2014 10:00:00')->format('U'),
+						'workboardPHID' => $this->testProjectPHID,
+						'oldColumnPHID' => 'anyNotClosed',
+						'newColumnPHID' => $this->closedColumnPHIDs[1],
+					]),
 				],
 			]
 		);
@@ -233,16 +233,16 @@ class BurndownChartTest extends TestCase {
 		$burndown = $this->mockWithTransactionsInWorkboardMode(
 			$this->tasks,
 			[
-				'1' => [new StatusChangeTransaction(
-					'1418040000', // Dec 8
-					'open',
-					'resolved'
-				)],
-				'2' => [new StatusChangeTransaction(
-					'1418050000', // Dec 8
-					'open',
-					'resolved'
-				)]
+				'1' => [new StatusChangeTransaction([
+					'timestamp' => '1418040000', // Dec 8
+					'oldStatus' => 'open',
+					'newStatus' => 'resolved',
+				])],
+				'2' => [new StatusChangeTransaction([
+					'timestamp' => '1418050000', // Dec 8
+					'oldStatus' => 'open',
+					'newStatus' => 'resolved',
+				])]
 			]
 		);
 
@@ -261,11 +261,11 @@ class BurndownChartTest extends TestCase {
 				'assigneePHID' => null,
 				'points' => 5,
 			])],
-			['500' => [new StatusChangeTransaction(
-				'1415664000', // Nov 11
-				'open',
-				'resolved'
-			)]]
+			['500' => [new StatusChangeTransaction([
+				'timestamp' => '1415664000', // Nov 11
+				'oldStatus' => 'open',
+				'newStatus' => 'resolved',
+			])]]
 		);
 
 		$this->assertNull($burndown->getPointsClosedBeforeSprint());

--- a/tests/unit/BurndownChartTest.php
+++ b/tests/unit/BurndownChartTest.php
@@ -4,6 +4,9 @@ use Phragile\BurndownChart;
 use Phragile\ClosedTimeByStatusFieldDispatcher;
 use Phragile\ClosedTimeByWorkboardDispatcher;
 use Phragile\ClosedTimeDispatcher;
+use Phragile\ColumnChangeTransaction;
+use Phragile\MergedIntoTransaction;
+use Phragile\StatusChangeTransaction;
 use Phragile\Task;
 
 class BurndownChartTest extends TestCase {
@@ -81,18 +84,20 @@ class BurndownChartTest extends TestCase {
 		$burndown = $this->mockWithTransactions(
 			$this->tasks,
 			[
-				'1' => [[
-					'transactionType' => 'status',
-					'oldValue' => 'open',
-					'newValue' => 'resolved',
-					'dateCreated' => '1418040000', // Dec 8
-				]],
-				'2' => [[
-					'transactionType' => 'status',
-					'oldValue' => 'open',
-					'newValue' => 'resolved',
-					'dateCreated' => '1418050000', // Dec 8
-				]]
+				'1' => [
+					new StatusChangeTransaction(
+						'1418040000', // Dec 8
+						'open',
+						'resolved'
+					)
+				],
+				'2' => [
+					new StatusChangeTransaction(
+						'1418050000',
+						'open',
+						'resolved'
+					)
+				]
 			]
 		);
 
@@ -103,12 +108,11 @@ class BurndownChartTest extends TestCase {
 	{
 		$burndown = $this->mockWithTransactions(
 			$this->tasks,
-			['1' => [[
-				'transactionType' => 'status',
-				'oldValue' => 'open',
-				'newValue' => 'resolved',
-				'dateCreated' => '1415664000', // Nov 11
-			]]]
+			['1' => [new StatusChangeTransaction(
+				'1415664000', // Nov 11
+				'open',
+				'resolved'
+			)]]
 		);
 
 		$this->assertSame(8, $burndown->getPointsClosedBeforeSprint());
@@ -120,18 +124,16 @@ class BurndownChartTest extends TestCase {
 			['1' => $this->tasks['1']],
 			[
 				'1' => [
-					[
-						'transactionType' => 'status',
-						'oldValue' => 'open',
-						'newValue' => 'resolved',
-						'dateCreated' => '1418040000', // Dec 8
-					],
-					[
-						'transactionType' => 'status',
-						'oldValue' => 'resolved',
-						'newValue' => 'invalid',
-						'dateCreated' => '1418130000', // Dec 9
-					]
+					new StatusChangeTransaction(
+						'1418040000', // Dec 8
+						'open',
+						'resolved'
+					),
+					new StatusChangeTransaction(
+						'1418130000', // Dec 9
+						'resolved',
+						'invalid'
+					)
 				]
 			]
 		);
@@ -147,24 +149,21 @@ class BurndownChartTest extends TestCase {
 			['1' => $this->tasks['1']],
 			[
 				'1' => [
-					[
-						'transactionType' => 'status',
-						'oldValue' => 'open',
-						'newValue' => 'resolved',
-						'dateCreated' => '1418040000', // Dec 8
-					],
-					[
-						'transactionType' => 'status',
-						'oldValue' => 'resolved',
-						'newValue' => 'open',
-						'dateCreated' => '1418050000',
-					],
-					[
-						'transactionType' => 'status',
-						'oldValue' => 'open',
-						'newValue' => 'resolved',
-						'dateCreated' => '1418130000', // Dec 9
-					]
+					new StatusChangeTransaction(
+						'1418040000', // Dec 8
+						'open',
+						'resolved'
+					),
+					new StatusChangeTransaction(
+						'1418050000',
+						'resolved',
+						'open'
+					),
+					new StatusChangeTransaction(
+						'1418130000', // Dec 9
+						'open',
+						'resolved'
+					)
 				]
 			]
 		);
@@ -179,24 +178,18 @@ class BurndownChartTest extends TestCase {
 		$burndown = $this->mockWithTransactionsInWorkboardMode(
 			$this->tasks,
 			[
-				'1' => [[
-					'transactionType' => 'core:columns',
-					'newValue' => [[
-						'fromColumnPHIDs' => ['anyNotClosed' => 'anyNotClosed'],
-						'columnPHID' => $this->closedColumnPHIDs[1],
-						'boardPHID' => $this->testProjectPHID,
-					]],
-					'dateCreated' => '1418040000', // Dec 8
-				]],
-				'2' => [[
-					'transactionType' => 'core:columns',
-					'newValue' => [[
-						'fromColumnPHIDs' => ['anyNotClosed' => 'anyNotClosed'],
-						'columnPHID' => $this->closedColumnPHIDs[0],
-						'boardPHID' => $this->testProjectPHID,
-					]],
-					'dateCreated' => '1418050000', // Dec 8
-				]]
+				'1' => [new ColumnChangeTransaction(
+					'1418040000', // Dec 8
+					$this->testProjectPHID,
+					'anyNotClosed',
+					$this->closedColumnPHIDs[1]
+				)],
+				'2' => [new \Phragile\ColumnChangeTransaction(
+					'1418050000', // Dec 8
+					$this->testProjectPHID,
+					'anyNotClosed',
+					$this->closedColumnPHIDs[0]
+				)]
 			]
 		);
 
@@ -209,33 +202,24 @@ class BurndownChartTest extends TestCase {
 			$this->tasks,
 			[
 				'1' => [
-					[
-						'transactionType' => 'core:columns',
-						'newValue' => [[
-							'fromColumnPHIDs' => ['anyNotClosed' => 'anyNotClosed'],
-							'columnPHID' => $this->closedColumnPHIDs[1],
-							'boardPHID' => $this->testProjectPHID,
-						]],
-						'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 10:00:00')->format('U'),
-					],
-					[
-						'transactionType' => 'core:columns',
-						'newValue' => [[
-							'fromColumnPHIDs' => [$this->closedColumnPHIDs[1] => $this->closedColumnPHIDs[1]],
-							'columnPHID' => 'anyNotClosed',
-							'boardPHID' => $this->testProjectPHID,
-						]],
-						'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 12:00:00')->format('U'),
-					],
-					[
-						'transactionType' => 'core:columns',
-						'newValue' => [[
-							'fromColumnPHIDs' => ['anyNotClosed' => 'anyNotClosed'],
-							'columnPHID' => $this->closedColumnPHIDs[1],
-							'boardPHID' => $this->testProjectPHID,
-						]],
-						'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '09.12.2014 10:00:00')->format('U'),
-					],
+					new ColumnChangeTransaction(
+						DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 10:00:00')->format('U'),
+						$this->testProjectPHID,
+						'anyNotClosed',
+						$this->closedColumnPHIDs[1]
+					),
+					new ColumnChangeTransaction(
+						DateTime::createFromFormat('d.m.Y H:i:s', '08.12.2014 12:00:00')->format('U'),
+						$this->testProjectPHID,
+						$this->closedColumnPHIDs[1],
+						'anyNotClosed'
+					),
+					new ColumnChangeTransaction(
+						DateTime::createFromFormat('d.m.Y H:i:s', '09.12.2014 10:00:00')->format('U'),
+						$this->testProjectPHID,
+						'anyNotClosed',
+						$this->closedColumnPHIDs[1]
+					),
 				],
 			]
 		);
@@ -249,18 +233,16 @@ class BurndownChartTest extends TestCase {
 		$burndown = $this->mockWithTransactionsInWorkboardMode(
 			$this->tasks,
 			[
-				'1' => [[
-					'transactionType' => 'status',
-					'oldValue' => 'open',
-					'newValue' => 'resolved',
-					'dateCreated' => '1418040000', // Dec 8
-				]],
-				'2' => [[
-					'transactionType' => 'status',
-					'oldValue' => 'open',
-					'newValue' => 'resolved',
-					'dateCreated' => '1418050000', // Dec 8
-				]]
+				'1' => [new StatusChangeTransaction(
+					'1418040000', // Dec 8
+					'open',
+					'resolved'
+				)],
+				'2' => [new StatusChangeTransaction(
+					'1418050000', // Dec 8
+					'open',
+					'resolved'
+				)]
 			]
 		);
 
@@ -279,12 +261,11 @@ class BurndownChartTest extends TestCase {
 				'assigneePHID' => null,
 				'points' => 5,
 			])],
-			['500' => [[ // this transaction's task is not closed and should be ignored
-				'transactionType' => 'status',
-				'oldValue' => 'open',
-				'newValue' => 'resolved',
-				'dateCreated' => '1415664000', // Nov 11
-			]]]
+			['500' => [new StatusChangeTransaction(
+				'1415664000', // Nov 11
+				'open',
+				'resolved'
+			)]]
 		);
 
 		$this->assertNull($burndown->getPointsClosedBeforeSprint());
@@ -295,10 +276,9 @@ class BurndownChartTest extends TestCase {
 		$burndown = $this->mockWithTransactions(
 			$this->tasks,
 			[
-				'1' => [[
-					        'transactionType' => 'mergedinto',
-					        'dateCreated' => '1418040000', // Dec 8
-				        ]],
+				'1' => [new MergedIntoTransaction(
+					'1418040000' // Dec 8
+				)]
 			]
 		);
 

--- a/tests/unit/ClosedTimeByWorkboardDispatcherTest.php
+++ b/tests/unit/ClosedTimeByWorkboardDispatcherTest.php
@@ -12,88 +12,88 @@ class ClosedTimeByWorkboardDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testGivenColumnTransactionOfDifferentProject_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
-			'1451638800',
-			'PHID-666',
-			'PHID-123todo',
-			'PHID-123done'
-		)));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-666',
+			'oldColumnPHID' => 'PHID-123todo',
+			'newColumnPHID' => 'PHID-123done',
+		])));
 	}
 
 	public function testGivenNonColumnRelatedTransaction_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction(new StatusChangeTransaction(
-			'1451638800',
-			null,
-			'open'
-		)));
+		$this->assertFalse($dispatcher->isClosingTransaction(new StatusChangeTransaction([
+			'timestamp' => '1451638800',
+			'oldStatus' => null,
+			'newStatus' => 'open',
+		])));
 	}
 
 	public function testWhenMovingFromNotClosedToClosedColumn_isClosingTransactionReturnsTrue()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertTrue($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
-			'1451638800',
-			'PHID-123',
-			'PHID-123todo',
-			'PHID-123done'
-		)));
+		$this->assertTrue($dispatcher->isClosingTransaction(new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => 'PHID-123todo',
+			'newColumnPHID' => 'PHID-123done',
+		])));
 	}
 
 	public function testWhenMovingFromNotClosedToNotClosedColumn_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
-			'1451638800',
-			'PHID-123',
-			'PHID-123todo',
-			'PHID-123doing'
-		)));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => 'PHID-123todo',
+			'newColumnPHID' => 'PHID-123doing',
+		])));
 	}
 
 	public function testWhenMovingFromUnspecifiedColumnToClosedColumn_isClosingTransactionReturnsTrue()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertTrue($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
-			'1451638800',
-			'PHID-123',
-			false,
-			'PHID-123done'
-		)));
+		$this->assertTrue($dispatcher->isClosingTransaction(new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => false,
+			'newColumnPHID' => 'PHID-123done',
+		])));
 	}
 
 	public function testWhenMovingFromUnspecifiedColumnToNotClosedColumn_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
-			'1451638800',
-			'PHID-123',
-			false,
-			'PHID-123todo'
-		)));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => false,
+			'newColumnPHID' => 'PHID-123todo',
+		])));
 	}
 
 	public function testWhenMovingBetweenClosedColumns_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done','PHID-123wontfix']);
-		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
-			'1451638800',
-			'PHID-123',
-			'PHID-123done',
-			'PHID-123wontfix'
-		)));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => 'PHID-123done',
+			'newColumnPHID' => 'PHID-123wontfix',
+		])));
 	}
 
 	public function testWhenMovingBetweenNotClosedColumns_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
-			'1451638800',
-			'PHID-123',
-			'PHID-123todo',
-			'PHID-123doing'
-		)));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => 'PHID-123todo',
+			'newColumnPHID' => 'PHID-123doing',
+		])));
 	}
 
 }

--- a/tests/unit/ClosedTimeByWorkboardDispatcherTest.php
+++ b/tests/unit/ClosedTimeByWorkboardDispatcherTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use Phragile\ClosedTimeByWorkboardDispatcher;
+use Phragile\ColumnChangeTransaction;
+use Phragile\StatusChangeTransaction;
 
 /**
  * @covers Phragile\ClosedTimeByWorkboardDispatcher
@@ -10,102 +12,88 @@ class ClosedTimeByWorkboardDispatcherTest extends PHPUnit_Framework_TestCase {
 	public function testGivenColumnTransactionOfDifferentProject_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction([
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => ['PHID-123todo' => 'PHID-123todo'],
-				'columnPHID' => 'PHID-123done',
-				'boardPHID' => 'PHID-666',
-			]],
-		]));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
+			'1451638800',
+			'PHID-666',
+			'PHID-123todo',
+			'PHID-123done'
+		)));
 	}
 
 	public function testGivenNonColumnRelatedTransaction_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction([
-			'transactionType' => 'status',
-			'oldValue' => '',
-			'newValue' => 'open',
-		]));
+		$this->assertFalse($dispatcher->isClosingTransaction(new StatusChangeTransaction(
+			'1451638800',
+			'', // TODO: shouldn't this be null?
+			'open'
+		)));
 	}
 
 	public function testWhenMovingFromNotClosedToClosedColumn_isClosingTransactionReturnsTrue()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertTrue($dispatcher->isClosingTransaction([
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => ['PHID-123todo' => 'PHID-123todo'],
-				'columnPHID' => 'PHID-123done',
-				'boardPHID' => 'PHID-123',
-			]],
-		]));
+		$this->assertTrue($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
+			'1451638800',
+			'PHID-123',
+			'PHID-123todo',
+			'PHID-123done'
+		)));
 	}
 
 	public function testWhenMovingFromNotClosedToNotClosedColumn_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction([
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => ['PHID-123todo' => 'PHID-123todo'],
-				'columnPHID' => 'PHID-123doing',
-				'boardPHID' => 'PHID-123',
-			]],
-		]));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
+			'1451638800',
+			'PHID-123',
+			'PHID-123todo',
+			'PHID-123doing'
+		)));
 	}
 
 	public function testWhenMovingFromUnspecifiedColumnToClosedColumn_isClosingTransactionReturnsTrue()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertTrue($dispatcher->isClosingTransaction([
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => [],
-				'columnPHID' => 'PHID-123done',
-				'boardPHID' => 'PHID-123',
-			]],
-		]));
+		$this->assertTrue($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
+			'1451638800',
+			'PHID-123',
+			false,
+			'PHID-123done'
+		)));
 	}
 
 	public function testWhenMovingFromUnspecifiedColumnToNotClosedColumn_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction([
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => [],
-				'columnPHID' => 'PHID-123todo',
-				'boardPHID' => 'PHID-123',
-			]],
-		]));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
+			'1451638800',
+			'PHID-123',
+			false,
+			'PHID-123todo'
+		)));
 	}
 
 	public function testWhenMovingBetweenClosedColumns_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done','PHID-123wontfix']);
-		$this->assertFalse($dispatcher->isClosingTransaction([
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => ['PHID-123done' => 'PHID-123done'],
-				'columnPHID' => 'PHID-123wontfix',
-				'boardPHID' => 'PHID-123',
-			]],
-		]));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
+			'1451638800',
+			'PHID-123',
+			'PHID-123done',
+			'PHID-123wontfix'
+		)));
 	}
 
 	public function testWhenMovingBetweenNotClosedColumns_isClosingTransactionReturnsFalse()
 	{
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
-		$this->assertFalse($dispatcher->isClosingTransaction([
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => ['PHID-123todo' => 'PHID-123todo'],
-				'columnPHID' => 'PHID-123doing',
-				'boardPHID' => 'PHID-123',
-			]],
-		]));
+		$this->assertFalse($dispatcher->isClosingTransaction(new ColumnChangeTransaction(
+			'1451638800',
+			'PHID-123',
+			'PHID-123todo',
+			'PHID-123doing'
+		)));
 	}
 
 }

--- a/tests/unit/ClosedTimeByWorkboardDispatcherTest.php
+++ b/tests/unit/ClosedTimeByWorkboardDispatcherTest.php
@@ -25,7 +25,7 @@ class ClosedTimeByWorkboardDispatcherTest extends PHPUnit_Framework_TestCase {
 		$dispatcher = new ClosedTimeByWorkboardDispatcher('PHID-123', ['PHID-123done']);
 		$this->assertFalse($dispatcher->isClosingTransaction(new StatusChangeTransaction(
 			'1451638800',
-			'', // TODO: shouldn't this be null?
+			null,
 			'open'
 		)));
 	}

--- a/tests/unit/ColumnChangeTransactionTest.php
+++ b/tests/unit/ColumnChangeTransactionTest.php
@@ -9,7 +9,12 @@ class ColumnChangeTransactionTest extends PHPUnit_Framework_TestCase {
 
 	public function testConstructorSetFields()
 	{
-		$transaction = new ColumnChangeTransaction('1451638800', 'PHID-PROJ-123', 'PHID-PCOL-123', 'PHID-PCOL-456');
+		$transaction = new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-PROJ-123',
+			'oldColumnPHID' => 'PHID-PCOL-123',
+			'newColumnPHID' => 'PHID-PCOL-456',
+		]);
 		$this->assertEquals('PHID-PROJ-123', $transaction->getWorkboardPHID());
 		$this->assertEquals('PHID-PCOL-123', $transaction->getOldColumnPHID());
 		$this->assertEquals('PHID-PCOL-456', $transaction->getNewColumnPHID());
@@ -21,7 +26,12 @@ class ColumnChangeTransactionTest extends PHPUnit_Framework_TestCase {
 
 	public function testConstructorNoOldColumn()
 	{
-		$transaction = new ColumnChangeTransaction('1451638800', 'PHID-PROJ-123', null, 'PHID-PCOL-123');
+		$transaction = new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-PROJ-123',
+			'oldColumnPHID' => null,
+			'newColumnPHID' => 'PHID-PCOL-123'
+		]);
 		$this->assertEquals('PHID-PROJ-123', $transaction->getWorkboardPHID());
 		$this->assertNull($transaction->getOldColumnPHID());
 		$this->assertEquals('PHID-PCOL-123', $transaction->getNewColumnPHID());
@@ -31,9 +41,44 @@ class ColumnChangeTransactionTest extends PHPUnit_Framework_TestCase {
 		);
 	}
 
+	public function incompleteAttributes()
+	{
+		$completeAttributes = [
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-PROJ-123',
+			'oldColumnPHID' => 'PHID-PCOL-123',
+			'newColumnPHID' => 'PHID-PCOL-456',
+		];
+		$attributeCombinations = [];
+
+		foreach (array_keys($completeAttributes) as $key)
+		{
+			$combination = $completeAttributes;
+			unset($combination[$key]);
+			$attributeCombinations[] = [$key, $combination];
+		}
+
+		return $attributeCombinations;
+	}
+
+	/**
+	 * @dataProvider incompleteAttributes
+	 */
+	public function testThrowsExceptionWithMissingAttributes($missingField, $incompleteAttributes)
+	{
+		$expectedExceptionMessage = 'The ' . $missingField  .' field is missing';
+		$this->setExpectedException(InvalidArgumentException::class, $expectedExceptionMessage);
+		new ColumnChangeTransaction($incompleteAttributes);
+	}
+
 	public function testGetTransactionData()
 	{
-		$transaction = new ColumnChangeTransaction('1451638800', 'PHID-PROJ-123', 'PHID-PCOL-123', 'PHID-PCOL-456');
+		$transaction = new ColumnChangeTransaction([
+			'timestamp' => '1451638800',
+			'workboardPHID' => 'PHID-PROJ-123',
+			'oldColumnPHID' => 'PHID-PCOL-123',
+			'newColumnPHID' => 'PHID-PCOL-456',
+		]);
 		$this->assertEquals(
 			[
 				'type' => 'columnChange',

--- a/tests/unit/ColumnChangeTransactionTest.php
+++ b/tests/unit/ColumnChangeTransactionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use Phragile\ColumnChangeTransaction;
+
+/**
+ * @covers Phragile\ColumnChangeTransaction
+ */
+class ColumnChangeTransactionTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructorSetFields()
+	{
+		$transaction = new ColumnChangeTransaction('1451638800', 'PHID-PROJ-123', 'PHID-PCOL-123', 'PHID-PCOL-456');
+		$this->assertEquals('PHID-PROJ-123', $transaction->getWorkboardPHID());
+		$this->assertEquals('PHID-PCOL-123', $transaction->getOldColumnPHID());
+		$this->assertEquals('PHID-PCOL-456', $transaction->getNewColumnPHID());
+		$this->assertEquals(
+			'01.01.2016',
+			DateTime::createFromFormat('U', $transaction->getTimestamp())->format('d.m.Y')
+		);
+
+	}
+
+	// TODO: tests for no old column case!
+
+	public function testGetTransactionData()
+	{
+		$transaction = new ColumnChangeTransaction('1451638800', 'PHID-PROJ-123', 'PHID-PCOL-123', 'PHID-PCOL-456');
+		$this->assertEquals(
+			[
+				'type' => 'columnChange',
+				'timestamp' => '1451638800',
+				'workboardPHID' => 'PHID-PROJ-123',
+				'oldColumnPHID' => 'PHID-PCOL-123',
+				'newColumnPHID' => 'PHID-PCOL-456',
+			],
+			$transaction->getTransactionData()
+		);
+	}
+
+}

--- a/tests/unit/ColumnChangeTransactionTest.php
+++ b/tests/unit/ColumnChangeTransactionTest.php
@@ -17,10 +17,19 @@ class ColumnChangeTransactionTest extends PHPUnit_Framework_TestCase {
 			'01.01.2016',
 			DateTime::createFromFormat('U', $transaction->getTimestamp())->format('d.m.Y')
 		);
-
 	}
 
-	// TODO: tests for no old column case!
+	public function testConstructorNoOldColumn()
+	{
+		$transaction = new ColumnChangeTransaction('1451638800', 'PHID-PROJ-123', null, 'PHID-PCOL-123');
+		$this->assertEquals('PHID-PROJ-123', $transaction->getWorkboardPHID());
+		$this->assertNull($transaction->getOldColumnPHID());
+		$this->assertEquals('PHID-PCOL-123', $transaction->getNewColumnPHID());
+		$this->assertEquals(
+			'01.01.2016',
+			DateTime::createFromFormat('U', $transaction->getTimestamp())->format('d.m.Y')
+		);
+	}
 
 	public function testGetTransactionData()
 	{

--- a/tests/unit/MergedIntoTransactionTest.php
+++ b/tests/unit/MergedIntoTransactionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Phragile\MergedIntoTransaction;
+
+/**
+ * @covers Phragile\MergedIntoTransaction
+ */
+class MergedIntoTransactionTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructorSetsFields()
+	{
+		$transaction = new MergedIntoTransaction('1451638800');
+		$this->assertEquals(
+			'01.01.2016',
+			DateTime::createFromFormat('U', $transaction->getTimestamp())->format('d.m.Y')
+		);
+	}
+
+	public function testGetTransactionData()
+	{
+		$transaction = new MergedIntoTransaction('1451638800');
+		$this->assertEquals(
+			[
+				'type' => 'mergedInto',
+				'timestamp' => '1451638800',
+			],
+			$transaction->getTransactionData()
+		);
+	}
+
+}

--- a/tests/unit/ProjectColumnRepositoryTest.php
+++ b/tests/unit/ProjectColumnRepositoryTest.php
@@ -19,18 +19,18 @@ class ProjectColumnRepositoryTest extends PHPUnit_Framework_TestCase {
 	{
 		$transactions =	[
 			'task1' => [
-				new ColumnChangeTransaction(
-					DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
-					'PHID-PROJ-FOO',
-					'PHID-123abc',
-					'PHID-abc123'
-				),
-				new ColumnChangeTransaction(
-					DateTime::createFromFormat('d.m.Y H:i:s', '02.01.2016 10:00:00')->format('U'),
-					'PHID-PROJ-FOO',
-					'PHID-abc123',
-					'PHID-321cba'
-				),
+				new ColumnChangeTransaction([
+					'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
+					'workboardPHID' => 'PHID-PROJ-FOO',
+					'oldColumnPHID' => 'PHID-123abc',
+					'newColumnPHID' => 'PHID-abc123',
+				]),
+				new ColumnChangeTransaction([
+					'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '02.01.2016 10:00:00')->format('U'),
+					'workboardPHID' => 'PHID-PROJ-FOO',
+					'oldColumnPHID' => 'PHID-abc123',
+					'newColumnPHID' => 'PHID-321cba',
+				]),
 			],
 		];
 		return new ProjectColumnRepository('PHID-PROJ-FOO', $transactions, $this->newPhabricatorAPI());

--- a/tests/unit/ProjectColumnRepositoryTest.php
+++ b/tests/unit/ProjectColumnRepositoryTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Phragile\PhabricatorAPI;
+use Phragile\ColumnChangeTransaction;
 use Phragile\ProjectColumnRepository;
 
 /**
@@ -18,30 +19,18 @@ class ProjectColumnRepositoryTest extends PHPUnit_Framework_TestCase {
 	{
 		$transactions =	[
 			'task1' => [
-				[
-					'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
-					'transactionType' => 'projectcolumn',
-					'oldValue' => [
-						'columnPHIDs' => ['PHID-123abc'],
-						'projectPHID' => 'PHID-PROJ-FOO',
-					],
-					'newValue' => [
-						'columnPHIDs' => ['PHID-abc123'],
-						'projectPHID' => 'PHID-PROJ-FOO',
-					]
-				],
-				[
-					'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '02.01.2016 10:00:00')->format('U'),
-					'transactionType' => 'projectcolumn',
-					'oldValue' => [
-						'columnPHIDs' => ['PHID-abc123'],
-						'projectPHID' => 'PHID-PROJ-FOO',
-					],
-					'newValue' => [
-						'columnPHIDs' => ['PHID-321cba'],
-						'projectPHID' => 'PHID-PROJ-FOO',
-					]
-				],
+				new \Phragile\ColumnChangeTransaction(
+					DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
+					'PHID-PROJ-FOO',
+					'PHID-123abc',
+					'PHID-abc123'
+				),
+				new ColumnChangeTransaction(
+					DateTime::createFromFormat('d.m.Y H:i:s', '02.01.2016 10:00:00')->format('U'),
+					'PHID-PROJ-FOO',
+					'PHID-abc123',
+					'PHID-321cba'
+				),
 			],
 		];
 		return new ProjectColumnRepository('PHID-PROJ-FOO', $transactions, $this->newPhabricatorAPI());

--- a/tests/unit/ProjectColumnRepositoryTest.php
+++ b/tests/unit/ProjectColumnRepositoryTest.php
@@ -19,7 +19,7 @@ class ProjectColumnRepositoryTest extends PHPUnit_Framework_TestCase {
 	{
 		$transactions =	[
 			'task1' => [
-				new \Phragile\ColumnChangeTransaction(
+				new ColumnChangeTransaction(
 					DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
 					'PHID-PROJ-FOO',
 					'PHID-123abc',

--- a/tests/unit/SortedTransactionListTest.php
+++ b/tests/unit/SortedTransactionListTest.php
@@ -33,17 +33,20 @@ class SortedTransactionListTest extends PHPUnit_Framework_TestCase {
 			]
 		];
 		$sortedTransactions = (new SortedTransactionList($transactions))->getTransactions();
+		$this->assertArrayHasKey('fooTask', $sortedTransactions);
+		/** @var ColumnChangeTransaction[] $fooTaskTransactions */
+		$fooTaskTransactions = $sortedTransactions['fooTask'];
 		$this->assertEquals(
 			'01.01.2016',
-			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][0]->getTimestamp())->format('d.m.Y')
+			DateTime::createFromFormat('U', $fooTaskTransactions[0]->getTimestamp())->format('d.m.Y')
 		);
 		$this->assertEquals(
 			'02.01.2016',
-			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][1]->getTimestamp())->format('d.m.Y')
+			DateTime::createFromFormat('U', $fooTaskTransactions[1]->getTimestamp())->format('d.m.Y')
 		);
 		$this->assertEquals(
 			'03.01.2016',
-			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][2]->getTimestamp())->format('d.m.Y')
+			DateTime::createFromFormat('U', $fooTaskTransactions[2]->getTimestamp())->format('d.m.Y')
 		);
 	}
 

--- a/tests/unit/SortedTransactionListTest.php
+++ b/tests/unit/SortedTransactionListTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Phragile\ColumnChangeTransaction;
 use Phragile\SortedTransactionList;
 
 /**
@@ -11,56 +12,38 @@ class SortedTransactionListTest extends PHPUnit_Framework_TestCase {
 	{
 		$transactions = [
 			'fooTask' => [
-				[
-					'dateCreated' => DateTime::createFromFormat('d.m.Y', '02.01.2016')->format('U'),
-					'transactionType' => 'projectcolumn',
-					'oldValue' => [
-						'columnPHIDs' => ['PHID-doing'],
-						'projectPHID' => 'PHID-PROJ-AWESOME',
-					],
-					'newValue' => [
-						'columnPHIDs' => ['PHID-done'],
-						'projectPHID' => 'PHID-PROJ-AWESOME',
-					]
-				],
-				[
-					'dateCreated' => DateTime::createFromFormat('d.m.Y', '01.01.2016')->format('U'),
-					'transactionType' => 'projectcolumn',
-					'oldValue' => [
-						'columnPHIDs' => ['PHID-backlog'],
-						'projectPHID' => 'PHID-PROJ-AWESOME',
-					],
-					'newValue' => [
-						'columnPHIDs' => ['PHID-doing'],
-						'projectPHID' => 'PHID-PROJ-AWESOME',
-					]
-				],
-				[
-					'dateCreated' => DateTime::createFromFormat('d.m.Y', '03.01.2016')->format('U'),
-					'transactionType' => 'projectcolumn',
-					'oldValue' => [
-						'columnPHIDs' => ['PHID-doing'],
-						'projectPHID' => 'PHID-PROJ-AWESOME',
-					],
-					'newValue' => [
-						'columnPHIDs' => ['PHID-done'],
-						'projectPHID' => 'PHID-PROJ-AWESOME',
-					]
-				],
+				new ColumnChangeTransaction(
+					DateTime::createFromFormat('d.m.Y', '02.01.2016')->format('U'),
+					'PHID-PROJ-AWESOME',
+					'PHID-doing',
+					'PHID-done'
+				),
+				new ColumnChangeTransaction(
+					DateTime::createFromFormat('d.m.Y', '01.01.2016')->format('U'),
+					'PHID-PROJ-AWESOME',
+					'PHID-backlog',
+					'PHID-doing'
+				),
+				new ColumnChangeTransaction(
+					DateTime::createFromFormat('d.m.Y', '03.01.2016')->format('U'),
+					'PHID-PROJ-AWESOME',
+					'PHID-doing',
+					'PHID-done'
+				),
 			]
 		];
 		$sortedTransactions = (new SortedTransactionList($transactions))->getTransactions();
 		$this->assertEquals(
 			'01.01.2016',
-			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][0]['dateCreated'])->format('d.m.Y')
+			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][0]->getTimestamp())->format('d.m.Y')
 		);
 		$this->assertEquals(
 			'02.01.2016',
-			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][1]['dateCreated'])->format('d.m.Y')
+			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][1]->getTimestamp())->format('d.m.Y')
 		);
 		$this->assertEquals(
 			'03.01.2016',
-			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][2]['dateCreated'])->format('d.m.Y')
+			DateTime::createFromFormat('U', $sortedTransactions['fooTask'][2]->getTimestamp())->format('d.m.Y')
 		);
 	}
 

--- a/tests/unit/SortedTransactionListTest.php
+++ b/tests/unit/SortedTransactionListTest.php
@@ -12,24 +12,24 @@ class SortedTransactionListTest extends PHPUnit_Framework_TestCase {
 	{
 		$transactions = [
 			'fooTask' => [
-				new ColumnChangeTransaction(
-					DateTime::createFromFormat('d.m.Y', '02.01.2016')->format('U'),
-					'PHID-PROJ-AWESOME',
-					'PHID-doing',
-					'PHID-done'
-				),
-				new ColumnChangeTransaction(
-					DateTime::createFromFormat('d.m.Y', '01.01.2016')->format('U'),
-					'PHID-PROJ-AWESOME',
-					'PHID-backlog',
-					'PHID-doing'
-				),
-				new ColumnChangeTransaction(
-					DateTime::createFromFormat('d.m.Y', '03.01.2016')->format('U'),
-					'PHID-PROJ-AWESOME',
-					'PHID-doing',
-					'PHID-done'
-				),
+				new ColumnChangeTransaction([
+					'timestamp' => DateTime::createFromFormat('d.m.Y', '02.01.2016')->format('U'),
+					'workboardPHID' => 'PHID-PROJ-AWESOME',
+					'oldColumnPHID' => 'PHID-doing',
+					'newColumnPHID' => 'PHID-done',
+				]),
+				new ColumnChangeTransaction([
+					'timestamp' => DateTime::createFromFormat('d.m.Y', '01.01.2016')->format('U'),
+					'workboardPHID' => 'PHID-PROJ-AWESOME',
+					'oldColumnPHID' => 'PHID-backlog',
+					'newColumnPHID' => 'PHID-doing',
+				]),
+				new ColumnChangeTransaction([
+					'timestamp' => DateTime::createFromFormat('d.m.Y', '03.01.2016')->format('U'),
+					'workboardPHID' => 'PHID-PROJ-AWESOME',
+					'oldColumnPHID' => 'PHID-doing',
+					'newColumnPHID' => 'PHID-done',
+				]),
 			]
 		];
 		$sortedTransactions = (new SortedTransactionList($transactions))->getTransactions();

--- a/tests/unit/StatusByWorkboardDispatcherTest.php
+++ b/tests/unit/StatusByWorkboardDispatcherTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Phragile\ColumnChangeTransaction;
 use Phragile\PhabricatorAPI;
 use Phragile\ProjectColumnRepository;
 use Phragile\StatusByWorkboardDispatcher;
@@ -106,8 +107,7 @@ class StatusByWorkboardDispatcherTest extends TestCase {
 	{
 		$sprint = $this->newSprint();
 		$task = ['id' => 'fooTask'];
-		$transaction = $this->getFirstTransaction();
-		$transaction['newValue'][0]['boardPHID'] = 'PHID-SOME-OTHER-PROJ-PHID';
+		$transaction = $this->getTransactionForAnotherProject();
 		$dispatcher = $this->newDispatcher($sprint, ['fooTask' => [$transaction]]);
 		$this->assertEquals('backlog', $dispatcher->getStatus($task));
 		$this->assertFalse($dispatcher->isClosed($task));
@@ -115,41 +115,42 @@ class StatusByWorkboardDispatcherTest extends TestCase {
 
 	private function getFirstTransaction()
 	{
-		return [
-			'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => [$this->getColumnPhid('to do') => $this->getColumnPhid('to do')],
-				'columnPHID' => $this->getColumnPhid('done'),
-				'boardPHID' => 'PHID-123',
-			]]
-		];
+		return new ColumnChangeTransaction(
+			DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
+			'PHID-123',
+			$this->getColumnPhid('to do'),
+			$this->getColumnPhid('done')
+		);
 	}
 
 	private function getSecondTransaction()
 	{
-		return [
-			'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 12:00:00')->format('U'),
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => [$this->getColumnPhid('done') => $this->getColumnPhid('done')],
-				'columnPHID' => $this->getColumnPhid('to do'),
-				'boardPHID' => 'PHID-123',
-			]]
-		];
+		return new ColumnChangeTransaction(
+			DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 12:00:00')->format('U'),
+			'PHID-123',
+			$this->getColumnPhid('done'),
+			$this->getColumnPhid('to do')
+		);
 	}
 
 	private function getThirdTransaction()
 	{
-		return [
-			'dateCreated' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 13:00:00')->format('U'),
-			'transactionType' => 'core:columns',
-			'newValue' => [[
-				'fromColumnPHIDs' => [$this->getColumnPhid('to do') => $this->getColumnPhid('to do')],
-				'columnPHID' => $this->getColumnPhid('done'),
-				'boardPHID' => 'PHID-123',
-			]]
-		];
+		return new ColumnChangeTransaction(
+			DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 13:00:00')->format('U'),
+			'PHID-123',
+			$this->getColumnPhid('to do'),
+			$this->getColumnPhid('done')
+		);
+	}
+
+	private function getTransactionForAnotherProject()
+	{
+		return new ColumnChangeTransaction(
+			DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
+			'PHID-SOME-OTHER-PROJECT-PHID',
+			$this->getColumnPhid('to do'),
+			$this->getColumnPhid('done')
+		);
 	}
 
 	private function getColumnPhid($name)

--- a/tests/unit/StatusByWorkboardDispatcherTest.php
+++ b/tests/unit/StatusByWorkboardDispatcherTest.php
@@ -115,42 +115,42 @@ class StatusByWorkboardDispatcherTest extends TestCase {
 
 	private function getFirstTransaction()
 	{
-		return new ColumnChangeTransaction(
-			DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
-			'PHID-123',
-			$this->getColumnPhid('to do'),
-			$this->getColumnPhid('done')
-		);
+		return new ColumnChangeTransaction([
+			'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => $this->getColumnPhid('to do'),
+			'newColumnPHID' => $this->getColumnPhid('done'),
+		]);
 	}
 
 	private function getSecondTransaction()
 	{
-		return new ColumnChangeTransaction(
-			DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 12:00:00')->format('U'),
-			'PHID-123',
-			$this->getColumnPhid('done'),
-			$this->getColumnPhid('to do')
-		);
+		return new ColumnChangeTransaction([
+			'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 12:00:00')->format('U'),
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => $this->getColumnPhid('done'),
+			'newColumnPHID' => $this->getColumnPhid('to do'),
+		]);
 	}
 
 	private function getThirdTransaction()
 	{
-		return new ColumnChangeTransaction(
-			DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 13:00:00')->format('U'),
-			'PHID-123',
-			$this->getColumnPhid('to do'),
-			$this->getColumnPhid('done')
-		);
+		return new ColumnChangeTransaction([
+			'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 13:00:00')->format('U'),
+			'workboardPHID' => 'PHID-123',
+			'oldColumnPHID' => $this->getColumnPhid('to do'),
+			'newColumnPHID' => $this->getColumnPhid('done'),
+		]);
 	}
 
 	private function getTransactionForAnotherProject()
 	{
-		return new ColumnChangeTransaction(
-			DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
-			'PHID-SOME-OTHER-PROJECT-PHID',
-			$this->getColumnPhid('to do'),
-			$this->getColumnPhid('done')
-		);
+		return new ColumnChangeTransaction([
+			'timestamp' => DateTime::createFromFormat('d.m.Y H:i:s', '01.01.2016 10:00:00')->format('U'),
+			'workboardPHID' => 'PHID-SOME-OTHER-PROJECT-PHID',
+			'oldColumnPHID' => $this->getColumnPhid('to do'),
+			'newColumnPHID' => $this->getColumnPhid('done'),
+		]);
 	}
 
 	private function getColumnPhid($name)

--- a/tests/unit/StatusChangeTransactionTest.php
+++ b/tests/unit/StatusChangeTransactionTest.php
@@ -18,7 +18,16 @@ class StatusChangeTransactionTest extends PHPUnit_Framework_TestCase
 		);
 	}
 
-	// TODO: add tests for case when there is no old status (first status change)
+	public function testOldStatusCanBeNull()
+	{
+		$transaction = new StatusChangeTransaction('1451638800', null, 'open');
+		$this->assertNull($transaction->getOldStatus());
+		$this->assertEquals('open', $transaction->getNewStatus());
+		$this->assertEquals(
+			'01.01.2016',
+			DateTime::createFromFormat('U', $transaction->getTimestamp())->format('d.m.Y')
+		);
+	}
 
 	public function testGetTransactionData()
 	{

--- a/tests/unit/StatusChangeTransactionTest.php
+++ b/tests/unit/StatusChangeTransactionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Phragile\StatusChangeTransaction;
+
+/**
+ * @covers Phragile\StatusChangeTransaction
+ */
+class StatusChangeTransactionTest extends PHPUnit_Framework_TestCase
+{
+	public function testConstructorsSetsFields()
+	{
+		$transaction = new StatusChangeTransaction('1451638800', 'open', 'resolved');
+		$this->assertEquals('open', $transaction->getOldStatus());
+		$this->assertEquals('resolved', $transaction->getNewStatus());
+		$this->assertEquals(
+			'01.01.2016',
+			DateTime::createFromFormat('U', $transaction->getTimestamp())->format('d.m.Y')
+		);
+	}
+
+	// TODO: add tests for case when there is no old status (first status change)
+
+	public function testGetTransactionData()
+	{
+		$transaction = new StatusChangeTransaction('1451638800', 'open', 'resolved');
+		$this->assertEquals(
+			[
+				'type' => 'statusChange',
+				'timestamp' => '1451638800',
+				'oldStatus' => 'open',
+				'newStatus' => 'resolved',
+			],
+			$transaction->getTransactionData()
+		);
+	}
+
+}

--- a/tests/unit/StatusChangeTransactionTest.php
+++ b/tests/unit/StatusChangeTransactionTest.php
@@ -9,7 +9,11 @@ class StatusChangeTransactionTest extends PHPUnit_Framework_TestCase
 {
 	public function testConstructorsSetsFields()
 	{
-		$transaction = new StatusChangeTransaction('1451638800', 'open', 'resolved');
+		$transaction = new StatusChangeTransaction([
+			'timestamp' => '1451638800',
+			'oldStatus' => 'open',
+			'newStatus' => 'resolved',
+		]);
 		$this->assertEquals('open', $transaction->getOldStatus());
 		$this->assertEquals('resolved', $transaction->getNewStatus());
 		$this->assertEquals(
@@ -20,7 +24,11 @@ class StatusChangeTransactionTest extends PHPUnit_Framework_TestCase
 
 	public function testOldStatusCanBeNull()
 	{
-		$transaction = new StatusChangeTransaction('1451638800', null, 'open');
+		$transaction = new StatusChangeTransaction([
+			'timestamp' => '1451638800',
+			'oldStatus' => null,
+			'newStatus' => 'open',
+		]);
 		$this->assertNull($transaction->getOldStatus());
 		$this->assertEquals('open', $transaction->getNewStatus());
 		$this->assertEquals(
@@ -29,9 +37,42 @@ class StatusChangeTransactionTest extends PHPUnit_Framework_TestCase
 		);
 	}
 
+	public function incompleteAttributes()
+	{
+		$completeAttributes = [
+			'timestamp' => '1451638800',
+			'oldStatus' => 'open',
+			'newStatus' => 'resolved',
+		];
+		$attributeCombinations = [];
+
+		foreach (array_keys($completeAttributes) as $key)
+		{
+			$combination = $completeAttributes;
+			unset($combination[$key]);
+			$attributeCombinations[] = [$key, $combination];
+		}
+
+		return $attributeCombinations;
+	}
+
+	/**
+	 * @dataProvider incompleteAttributes
+	 */
+	public function testThrowsExceptionWithMissingAttributes($missingField, $incompleteAttributes)
+	{
+		$expectedExceptionMessage = 'The ' . $missingField  . ' field is missing';
+		$this->setExpectedException(InvalidArgumentException::class, $expectedExceptionMessage);
+		new StatusChangeTransaction($incompleteAttributes);
+	}
+
 	public function testGetTransactionData()
 	{
-		$transaction = new StatusChangeTransaction('1451638800', 'open', 'resolved');
+		$transaction = new StatusChangeTransaction([
+			'timestamp' => '1451638800',
+			'oldStatus' => 'open',
+			'newStatus' => 'resolved',
+		]);
 		$this->assertEquals(
 			[
 				'type' => 'statusChange',

--- a/tests/unit/TransactionRawDataProcessorTest.php
+++ b/tests/unit/TransactionRawDataProcessorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Phragile\ColumnChangeTransaction;
+use Phragile\MergedIntoTransaction;
+use Phragile\StatusChangeTransaction;
+use Phragile\TransactionRawDataProcessor;
+
+/**
+ * @covers Phragile\TransactionRawDataProcessor
+ */
+class TransactionRawDataProcessorTest extends PHPUnit_Framework_TestCase {
+
+	public function testProcessColumnChangeTransaction()
+	{
+		$rawData = [
+			'taskFoo' => [[
+				'dateCreated' => '1451638800', // 01.01.2016 10:00:00
+				'transactionType' => 'core:columns',
+				'newValue' => [[
+					'boardPHID' => 'PHID-PROJ-123',
+					'columnPHID' => 'PHID-PCOL-456',
+					'fromColumnPHIDs' => ['PHID-PCOL-123']
+				]]
+			]]
+		];
+
+		$processor = new TransactionRawDataProcessor();
+		$transactions = $processor->process($rawData);
+
+		$this->assertCount(1, $transactions);
+		$this->assertArrayHasKey('taskFoo', $transactions);
+
+		$this->assertCount(1, $transactions['taskFoo']);
+		$this->assertInstanceOf(ColumnChangeTransaction::class, $transactions['taskFoo'][0]);
+		$this->assertEquals('1451638800', $transactions['taskFoo'][0]->getTimestamp());
+		$this->assertEquals('PHID-PROJ-123', $transactions['taskFoo'][0]->getWorkboardPHID());
+		$this->assertEquals('PHID-PCOL-123', $transactions['taskFoo'][0]->getOldColumnPHID());
+		$this->assertEquals('PHID-PCOL-456', $transactions['taskFoo'][0]->getNewColumnPHID());
+	}
+
+	public function testProcessStatusChangeTransaction()
+	{
+		$rawData = [
+			'taskFoo' => [[
+				'dateCreated' => '1451638800', // 01.01.2016 10:00:00
+				'transactionType' => 'status',
+				'oldValue' => 'open',
+				'newValue' => 'resolved',
+			]]
+		];
+
+		$processor = new TransactionRawDataProcessor();
+		$transactions = $processor->process($rawData);
+
+		$this->assertCount(1, $transactions);
+		$this->assertArrayHasKey('taskFoo', $transactions);
+
+		$this->assertCount(1, $transactions['taskFoo']);
+		$this->assertInstanceOf(StatusChangeTransaction::class, $transactions['taskFoo'][0]);
+		$this->assertEquals('1451638800', $transactions['taskFoo'][0]->getTimestamp());
+		$this->assertEquals('open', $transactions['taskFoo'][0]->getOldStatus());
+		$this->assertEquals('resolved', $transactions['taskFoo'][0]->getNewStatus());
+	}
+
+	public function testProcessMergedIntoTransaction()
+	{
+		$rawData = [
+			'taskFoo' => [[
+				'dateCreated' => '1451638800', // 01.01.2016 10:00:00
+				'transactionType' => 'mergedinto',
+			]]
+		];
+
+		$processor = new TransactionRawDataProcessor();
+		$transactions = $processor->process($rawData);
+
+		$this->assertCount(1, $transactions);
+		$this->assertArrayHasKey('taskFoo', $transactions);
+
+		$this->assertCount(1, $transactions['taskFoo']);
+		$this->assertInstanceOf(MergedIntoTransaction::class, $transactions['taskFoo'][0]);
+		$this->assertEquals('1451638800', $transactions['taskFoo'][0]->getTimestamp());
+	}
+
+	public function testGivenNoTransactionType_processSkipsTransactionData()
+	{
+		$rawData = [
+			'taskFoo' => [[
+				'newValue' => 'someValue'
+			]]
+		];
+
+		$processor = new TransactionRawDataProcessor();
+		$transactions = $processor->process($rawData);
+
+		$this->assertEmpty($transactions['taskFoo']);
+	}
+
+}

--- a/tests/unit/TransactionSnapshotDataProcessorTest.php
+++ b/tests/unit/TransactionSnapshotDataProcessorTest.php
@@ -41,8 +41,17 @@ class TransactionSnapshotDataProcessorTest extends PHPUnit_Framework_TestCase {
 
 		$this->assertEquals([
 				'fooTask' => [
-					new ColumnChangeTransaction('1451638800', 'PHID-PROJ-123', 'PHID-PCOL-123', 'PHID-PCOL-456'),
-					new StatusChangeTransaction('1451642400', 'open', 'resolved')
+					new ColumnChangeTransaction([
+						'timestamp' => '1451638800',
+						'workboardPHID' => 'PHID-PROJ-123',
+						'oldColumnPHID' => 'PHID-PCOL-123',
+						'newColumnPHID' => 'PHID-PCOL-456',
+					]),
+					new StatusChangeTransaction([
+						'timestamp' => '1451642400',
+						'oldStatus' => 'open',
+						'newStatus' => 'resolved',
+					])
 				],
 				'bazTask' => [
 					new MergedIntoTransaction('1451646000')

--- a/tests/unit/TransactionSnapshotDataProcessorTest.php
+++ b/tests/unit/TransactionSnapshotDataProcessorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Phragile\ColumnChangeTransaction;
+use Phragile\MergedIntoTransaction;
+use Phragile\StatusChangeTransaction;
+use Phragile\TransactionSnapshotDataProcessor;
+
+/**
+ * @covers Phragile\TransactionSnapshotDataProcessor
+ */
+class TransactionSnapshotDataProcessorTest extends PHPUnit_Framework_TestCase {
+
+	public function testProcessConvertsTransactionsOfKnownTypes()
+	{
+		$snapshotData = [
+			'fooTask' => [
+				[
+					'timestamp' => '1451638800', // 01.01.2016 10:00:00
+					'type' => 'columnChange',
+					'workboardPHID' => 'PHID-PROJ-123',
+					'oldColumnPHID' => 'PHID-PCOL-123',
+					'newColumnPHID' => 'PHID-PCOL-456',
+				],
+				[
+					'timestamp' => '1451642400', // 01.01.2016 11:00:00
+					'type' => 'statusChange',
+					'oldStatus' => 'open',
+					'newStatus' => 'resolved'
+				],
+			],
+			'bazTask' => [
+				[
+					'timestamp' => '1451646000', // 01.01.2016 12:00:00
+					'type' => 'mergedInto'
+				],
+			],
+		];
+
+		$processor = new TransactionSnapshotDataProcessor();
+		$transactions = $processor->process($snapshotData);
+
+		$this->assertEquals([
+				'fooTask' => [
+					new ColumnChangeTransaction('1451638800', 'PHID-PROJ-123', 'PHID-PCOL-123', 'PHID-PCOL-456'),
+					new StatusChangeTransaction('1451642400', 'open', 'resolved')
+				],
+				'bazTask' => [
+					new MergedIntoTransaction('1451646000')
+				]
+			], $transactions
+		);
+	}
+
+	public function testGivenNoTypeKey_snapshotTransactionIsIgnored()
+	{
+		$snapshotData = [
+			'fooTask' => [
+				[
+					'timestamp' => '1451638800', // 01.01.2016 10:00:00
+					'workboardPHID' => 'PHID-PROJ-123',
+					'oldColumnPHID' => 'PHID-PCOL-123',
+					'newColumnPHID' => 'PHID-PCOL-456',
+				],
+			]
+		];
+
+		$processor = new TransactionSnapshotDataProcessor();
+		$transactions = $processor->process($snapshotData);
+
+		$this->assertEquals(['fooTask' => []], $transactions);
+	}
+
+	public function testGivenUnknownTypeKey_snapshotTransactionIsIgnored()
+	{
+		$snapshotData = [
+			'fooTask' => [
+				[
+					'timestamp' => '1451638800', // 01.01.2016 10:00:00
+					'type' => 'someReallyReallyOddTransaction',
+				],
+			]
+		];
+
+		$processor = new TransactionSnapshotDataProcessor();
+		$transactions = $processor->process($snapshotData);
+
+		$this->assertEquals(['fooTask' => []], $transactions);
+	}
+
+}


### PR DESCRIPTION
It took me far more time than I expected but I've broken all things couple of times while I was changing exisiting stuff, but it is finally ready for others to have a look.

This PR is far from complete. There are multiple TODOs already marked in the code, and lots of others missing. I am submitting this a bit pre-maturely as a pull request as I hope to get opinions from others as soon as possible on the approach I have taken here.
So I am pinging @jakobw @addshore @WMDE-Fisch and all the people and ask for merciless review!

Idea: Currently transaction data is fetched from Phabricator API response and used both by Phragile classes as an internal data structure, and also used as a part of snapshots in unchanged form.
There is some filtering being done and only transactions relevant to status and column changes are taken over from Phabricator. Still, those data contain quite some information which is not used by Phragile. Also, whenever Phabricator changes its API there is a risk that the change will be a breaking change for Phabricator. This happened last week after changing the structure of column-change transactions in the API response (plus similar breaking change earlier this year, although related to tasks)

Approach I have used is basically stealing ideas from @jakobw's (task-related patch)[https://github.com/wmde/phragile/pull/215]. I have introduced "Processor" class that gets a json-decoded array from Phabricator and transforms the data into array of "*Transaction" class objects representing particular transaction types relevant to Phragile.
I think I went a bit further than @jakobw as here only classes that know anything of how looks API response are the Processor itself and the previously existing class filtering unwanted transactions (I think for example for performance reason it makes no sense to do the conversion before filtering). Also, arrays 

What is obviously missing here is a script to convert transaction data of already existing snapshots to the format which would be compatible with changes made here. It has to be done (and deployed) along with other changes. Given the already existing script converting task data, I would consider it a rather small remaining task.
Apart from that all normal operations of Phragile are supposed to be "generally" working:
 - live view of the sprint,
 - creating a new snapshot of the sprint using live data,
 - viewing the snapshot created _after_ this code has been introduced.

I have added some TODOs already. Some should be added to make the patch complete (e.g. testing of special cases), some will/would rather be considered in separate PRs.

This is a rather big patch, touching some like half of Phragile classes (probably exaggerated estimate), and I'd expect it to grow even bigger while missing things are added. I think it makes sense to do the general review of how things are being changed here first, focusing on the approach taken and discovering some obvious and critical flaws. Detailed whitespace-level review might be done once this is all finished functionality-wise.

Current division of the code introduced here into three commits is kind of artificial, I'd say as it all depends on each other. To make reviewing of the final change easier I'd try to divide it somehow, although it might be tricky.

I'd be glad to hear any comments on this rather big thing!