### PR TITLE
Rename Transaction Loader and Filter classes

### DIFF
--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -8,8 +8,8 @@ use Phragile\Presentation\TaskList;
 use Phragile\TaskPresenter;
 use Phragile\Domain\Transaction;
 use Phragile\TransactionRawDataProcessor;
-use Phragile\TransactionLoader;
-use Phragile\TransactionFilter;
+use Phragile\TransactionRawDataLoader;
+use Phragile\TransactionRawDataFilter;
 use Phragile\PhabricatorAPI;
 
 class Sprint extends Eloquent {
@@ -149,8 +149,8 @@ class Sprint extends Eloquent {
 		{
 			return $task['id'];
 		}, $tasks);
-		return (new TransactionLoader(
-			new TransactionFilter(),
+		return (new TransactionRawDataLoader(
+			new TransactionRawDataFilter(),
 			$phabricator
 		))->load($taskIDs);
 	}

--- a/app/Phragile/ActionHandler/SprintLiveDataActionHandler.php
+++ b/app/Phragile/ActionHandler/SprintLiveDataActionHandler.php
@@ -3,11 +3,11 @@
 namespace Phragile\ActionHandler;
 
 use Phragile\PhabricatorAPI;
-use Phragile\SettingsAwareTransactionFilter;
+use Phragile\SettingsAwareTransactionRawDataFilter;
 use Phragile\TaskDataFetcher;
 use Phragile\TaskRawDataProcessor;
 use Phragile\TransactionRawDataProcessor;
-use Phragile\TransactionLoader;
+use Phragile\TransactionRawDataLoader;
 use Sprint;
 use Phragile\Factory\SprintDataFactory;
 
@@ -49,8 +49,8 @@ class SprintLiveDataActionHandler {
 		}, $tasks);
 		$taskDataProcessor = new TaskRawDataProcessor();
 		$transactionDataProcessor = new TransactionRawDataProcessor();
-		$transactionLoader = new TransactionLoader(
-			new SettingsAwareTransactionFilter($sprint->project->workboard_mode),
+		$transactionLoader = new TransactionRawDataLoader(
+			new SettingsAwareTransactionRawDataFilter($sprint->project->workboard_mode),
 			$this->phabricatorAPI
 		);
 

--- a/app/Phragile/SettingsAwareTransactionRawDataFilter.php
+++ b/app/Phragile/SettingsAwareTransactionRawDataFilter.php
@@ -4,7 +4,7 @@ namespace Phragile;
 /**
  * Class for filtering out all transactions but the ones relevant to the task status according to the project settings
  */
-class SettingsAwareTransactionFilter extends TransactionFilter {
+class SettingsAwareTransactionRawDataFilter extends TransactionRawDataFilter {
 	private $workboardMode;
 
 	public function __construct($workboardMode)

--- a/app/Phragile/TransactionRawDataFilter.php
+++ b/app/Phragile/TransactionRawDataFilter.php
@@ -1,10 +1,9 @@
 <?php
 namespace Phragile;
 
-// TODO: rename to e.g. TransactionDataFilter
-class TransactionFilter {
+class TransactionRawDataFilter {
 	/**
-	 * Filters out irrelevant transactions
+	 * Filters out irrelevant transactions fetched from Phabricator
 	 *
 	 * @param array $transactions
 	 * @return array $transactions

--- a/app/Phragile/TransactionRawDataLoader.php
+++ b/app/Phragile/TransactionRawDataLoader.php
@@ -1,16 +1,15 @@
 <?php
 namespace Phragile;
 
-// TODO: rename to e.g. TransactionDataFetcher?
-class TransactionLoader {
+class TransactionRawDataLoader {
 	private $transactionFilter;
 	private $phabricatorAPI;
 
 	/**
-	 * @param TransactionFilter $transactionFilter
+	 * @param TransactionRawDataFilter $transactionFilter
 	 * @param PhabricatorAPI $phabricatorAPI
 	 */
-	public function __construct(TransactionFilter $transactionFilter, PhabricatorAPI $phabricatorAPI)
+	public function __construct(TransactionRawDataFilter $transactionFilter, PhabricatorAPI $phabricatorAPI)
 	{
 		$this->transactionFilter = $transactionFilter;
 		$this->phabricatorAPI = $phabricatorAPI;


### PR DESCRIPTION
Renaming as discussed somewhere in https://github.com/wmde/phragile/pull/240 (if you have enough patience to browse all comments over there!).
I am not really convinced about the length of `SettingsAwareTransactionRawDataFilter` class name