### PR TITLE
Convert column change transactions in "old" format

### DIFF
--- a/app/Console/Commands/Lib/SnapshotTransactionDataConverter.php
+++ b/app/Console/Commands/Lib/SnapshotTransactionDataConverter.php
@@ -18,6 +18,10 @@ class SnapshotTransactionDataConverter {
 
 	private function convertPhabricatorTransactionData(array $transactionData)
 	{
+		if ($this->transactionDataIsInPre2016Week15Format($transactionData))
+		{
+			$transactionData = $this->convertPre2016Week15Transactions($transactionData);
+		}
 		$processor = new TransactionRawDataProcessor();
 		return array_map(
 			function(array $taskTransactions)
@@ -49,6 +53,71 @@ class SnapshotTransactionDataConverter {
 		return array_key_exists('taskID', $transaction) && array_key_exists('dateCreated', $transaction) &&
 			array_key_exists('transactionType', $transaction) && array_key_exists('oldValue', $transaction) &&
 			array_key_exists('newValue', $transaction);
+	}
+
+	private function transactionDataIsInPre2016Week15Format(array $transactionData)
+	{
+		foreach ($transactionData as $taskId => $taskTransactions)
+		{
+			$pre2016Week15ColumnTransactions = array_filter(
+				$taskTransactions,
+				function(array $transaction)
+				{
+					return $transaction['transactionType'] === 'projectcolumn' &&
+						array_key_exists('columnPHIDs', $transaction['oldValue']) &&
+						array_key_exists('projectPHID', $transaction['oldValue']) &&
+						array_key_exists('columnPHIDs', $transaction['newValue']) &&
+						array_key_exists('projectPHID', $transaction['newValue']);
+				}
+			);
+			if (!empty($pre2016Week15ColumnTransactions))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private function convertPre2016Week15Transactions(array $transactionData)
+	{
+		return array_map(
+			function(array $taskTransactions)
+			{
+				return array_map(
+					function(array $transaction)
+					{
+						return $transaction['transactionType'] === 'projectcolumn'
+							? $this->convertPre2016Week15ColumnChangeTransaction($transaction)
+							: $transaction;
+					},
+					$taskTransactions
+				);
+			},
+			$transactionData
+		);
+	}
+
+	private function convertPre2016Week15ColumnChangeTransaction(array $transaction)
+	{
+		$projectPHID = $transaction['oldValue']['projectPHID'];
+		$newColumnPHID = $transaction['newValue']['columnPHIDs'][0];
+		$oldColumnPHID = reset($transaction['oldValue']['columnPHIDs']);
+		$fromColumnsPart = $oldColumnPHID !== false ? [$oldColumnPHID => $oldColumnPHID] : [];
+		$convertedTransactionData = [
+			'transactionType' => 'core:columns',
+			'oldValue' => null,
+			'newValue' => [
+				[
+					'columnPHID' => $newColumnPHID,
+					'boardPHID' => $projectPHID,
+					'fromColumnPHIDs' => $fromColumnsPart,
+				],
+			],
+		];
+		return array_merge(
+			$transaction,
+			$convertedTransactionData
+		);
 	}
 
 }

--- a/tests/unit/SnapshotTransactionDataConverterTest.php
+++ b/tests/unit/SnapshotTransactionDataConverterTest.php
@@ -13,6 +13,23 @@ class SnapshotTransactionDataConverterTest extends PHPUnit_Framework_TestCase {
 			'10' => [
 				[
 					'taskID' => '10',
+					'transactionID' => '574',
+					'transactionPHID' => 'PHID-XACT-TASK-thuitevwbsvzq3w',
+					'transactionType' => 'core:columns',
+					'oldValue' => null,
+					'newValue' => [
+						[
+							'columnPHID' => 'PHID-PCOL-4hyhg5eihidfzexjxo6l',
+							'boardPHID' => 'PHID-PROJ-we3kvpoegtfzytlzsbq5',
+							'fromColumnPHIDs' => [],
+						]
+					],
+					'comments' => null,
+					'authorPHID' => 'PHID-USER-4evwbszqu47ukghwqpyo',
+					'dateCreated' => '1461843396',
+				],
+				[
+					'taskID' => '10',
 					'transactionID' => '615',
 					'transactionPHID' => 'PHID-XACT-TASK-thuit5jaapizdv3',
 					'transactionType' => 'core:columns',
@@ -56,10 +73,85 @@ class SnapshotTransactionDataConverterTest extends PHPUnit_Framework_TestCase {
 		];
 	}
 
+	private function getPhabricatorPre2016Week15Transactions()
+	{
+		return [
+			'10' => [
+				'0' => [
+					'taskID' => '10',
+					'transactionID' => '574',
+					'transactionPHID' => 'PHID-XACT-TASK-thuitevwbsvzq3w',
+					'transactionType' => 'projectcolumn',
+					'oldValue' => [
+						'columnPHIDs' => [],
+						'projectPHID' => 'PHID-PROJ-we3kvpoegtfzytlzsbq5',
+					],
+					'newValue' => [
+						'columnPHIDs' => ['PHID-PCOL-4hyhg5eihidfzexjxo6l'],
+						'projectPHID' => 'PHID-PROJ-we3kvpoegtfzytlzsbq5',
+						'afterPHID' => null,
+						'beforePHID' => null,
+					],
+					'comments' => null,
+					'authorPHID' => 'PHID-USER-4evwbszqu47ukghwqpyo',
+					'dateCreated' => '1461843396',
+				],
+				'1' => [
+					'taskID' => '10',
+					'transactionID' => '615',
+					'transactionPHID' => 'PHID-XACT-TASK-thuit5jaapizdv3',
+					'transactionType' => 'projectcolumn',
+					'oldValue' => [
+						'columnPHIDs' => ['PHID-PCOL-4hyhg5eihidfzexjxo6l'],
+						'projectPHID' => 'PHID-PROJ-we3kvpoegtfzytlzsbq5',
+					],
+					'newValue' => [
+						'columnPHIDs' => ['PHID-PCOL-babqxkbnh75r3dyxmuys'],
+						'projectPHID' => 'PHID-PROJ-we3kvpoegtfzytlzsbq5',
+						'afterPHID' => null,
+						'beforePHID' => null,
+					],
+					'comments' => null,
+					'authorPHID' => 'PHID-USER-4evwbszqu47ukghwqpyo',
+					'dateCreated' => '1461852396',
+				],
+				'2' => [
+					'taskID' => '10',
+					'transactionID' => '85',
+					'transactionPHID' => 'PHID-XACT-TASK-fa4mch7cmvs56yp',
+					'transactionType' => 'status',
+					'oldValue' => null,
+					'newValue' => 'open',
+					'comments' => null,
+					'authorPHID' => 'PHID-USER-4evwbszqu47ukghwqpyo',
+					'dateCreated' => '1436877423',
+				],
+				'3' => [
+					'taskID' => '10',
+					'transactionID' => '87',
+					'transactionPHID' => 'PHID-XACT-TASK-gnhol6bzawe4fgi',
+					'transactionType' => 'mergedinto',
+					'oldValue' => null,
+					'newValue' => 'PHID-TASK-kbqbuddlt65redxoce6g',
+					'comments' => null,
+					'authorPHID' => 'PHID-USER-4evwbszqu47ukghwqpyo',
+					'dateCreated' => '1462366409',
+				]
+			]
+		];
+	}
+
 	private function getConvertedTransactions()
 	{
 		return [
 			'10' => [
+				[
+					'type' => 'columnChange',
+					'timestamp' => '1461843396',
+					'workboardPHID' => 'PHID-PROJ-we3kvpoegtfzytlzsbq5',
+					'oldColumnPHID' => false,
+					'newColumnPHID' => 'PHID-PCOL-4hyhg5eihidfzexjxo6l',
+				],
 				[
 					'type' => 'columnChange',
 					'timestamp' => '1461852396',
@@ -111,6 +203,19 @@ class SnapshotTransactionDataConverterTest extends PHPUnit_Framework_TestCase {
 		$expectedConvertedData = $this->getConvertedTransactions();
 		$converter = new SnapshotTransactionDataConverter();
 		$this->assertSame($expectedConvertedData, $converter->convert($this->getConvertedTransactions()));
+	}
+
+	public function testGivenPhabricatorJsonPre2016Week15Transactions_needsConversionReturnsTrue()
+	{
+		$converter = new SnapshotTransactionDataConverter();
+		$this->assertTrue($converter->needsConversion($this->getPhabricatorPre2016Week15Transactions()));
+	}
+
+	public function testGivenPhabricatorJsonPre2016Week15Transactions_convertReturnsConvertedData()
+	{
+		$expectedConvertedData = $this->getConvertedTransactions();
+		$converter = new SnapshotTransactionDataConverter();
+		$this->assertSame($expectedConvertedData, $converter->convert($this->getPhabricatorPre2016Week15Transactions()));
 	}
 
 	public function testGivenNoTransactionForTask_convertReturnsUnchangedData()


### PR DESCRIPTION
It looks like https://github.com/wmde/phragile/pull/245 was missing a very important bit, ie. it didn't convert column change transaction in format that Phabricator used prior to release 2016 Week 15. In other words, it didn't convert transactions stored in snapshots created before https://github.com/wmde/phragile/pull/238.

That is quite essential for Wikimedia Phragile as probably 90% if not more snapshots have transactions in this particular format. Currently migration script just dropped those transactions which results in charts with no changes!